### PR TITLE
Add transition animations and modernize UI

### DIFF
--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -5,6 +5,7 @@ use crate::gui::settings::{
 use crate::gui::tab::{ShellKind, TerminalTab, discover_available_shells};
 use crate::session::OutputEvent;
 use crate::terminal::font::discover_system_terminal_fonts;
+use iced::Animation;
 use iced::Size;
 use iced::futures::channel::mpsc;
 use iced::keyboard::{Key, Modifiers};
@@ -69,6 +70,7 @@ pub enum Message {
 
     WindowResized(Size),
     ResizeDebounce,
+    AnimationTick,
     ApplyWindowStyle,
 
     FontSelected(TerminalFontOption),
@@ -105,6 +107,7 @@ pub struct App {
     pub(super) resize_debounce_pending: bool,
     pub(super) resize_debounce_seq: u64,
     pub(super) resize_debounce_spawned_seq: u64,
+    pub(super) shell_picker_anim: Animation<bool>,
     pub(super) window_style_applied: bool,
     #[cfg(target_os = "macos")]
     pub(super) show_restart_confirm: bool,
@@ -145,6 +148,9 @@ impl App {
             resize_debounce_pending: false,
             resize_debounce_seq: 0,
             resize_debounce_spawned_seq: 0,
+            shell_picker_anim: Animation::new(false)
+                .duration(std::time::Duration::from_millis(250))
+                .easing(iced::animation::Easing::EaseOutQuint),
             window_style_applied: false,
             #[cfg(target_os = "macos")]
             show_restart_confirm: false,

--- a/src/gui/app/subscription.rs
+++ b/src/gui/app/subscription.rs
@@ -3,11 +3,22 @@ use iced::futures::StreamExt;
 use iced::futures::channel::mpsc;
 use iced::futures::sink::SinkExt;
 use iced::stream;
-use iced::{Event, Subscription, event, keyboard, mouse, window};
+use iced::time::Instant;
+use iced::{Event, Subscription, event, keyboard, mouse, time, window};
 
 impl App {
     pub fn subscription(&self) -> Subscription<Message> {
+        let now = Instant::now();
+        let has_animation = self.shell_picker_anim.is_animating(now);
+
+        let animation_tick = if has_animation {
+            time::every(std::time::Duration::from_millis(16)).map(|_| Message::AnimationTick)
+        } else {
+            Subscription::none()
+        };
+
         Subscription::batch([
+            animation_tick,
             Subscription::run(|| {
                 stream::channel(100, async |mut output| {
                     let (sender, mut receiver) = mpsc::channel(100);

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -6,6 +6,7 @@ use super::{App, Message, SETTINGS_TAB_INDEX};
 use crate::gui::settings::{SettingsDraft, SettingsField};
 use crate::gui::tab::ShellKind;
 use iced::keyboard::{Key, key::Named};
+use iced::time::Instant;
 use iced::{Task, widget};
 use std::sync::LazyLock;
 
@@ -31,10 +32,10 @@ impl App {
             Message::OpenShellPicker => {
                 self.show_shell_picker = true;
                 self.shell_picker_selected = 0;
+                self.shell_picker_anim.go_mut(true, Instant::now());
             }
             Message::CloseShellPicker => {
-                self.show_shell_picker = false;
-                self.shell_picker_selected = 0;
+                self.shell_picker_anim.go_mut(false, Instant::now());
             }
             Message::CreateTab(shell) => {
                 return self.create_tab(shell);
@@ -238,6 +239,13 @@ impl App {
             Message::WindowResized(size) => {
                 return self.handle_window_resized(size);
             }
+            Message::AnimationTick => {
+                let now = Instant::now();
+                if !self.shell_picker_anim.is_animating(now) && !self.shell_picker_anim.value() {
+                    self.show_shell_picker = false;
+                    self.shell_picker_selected = 0;
+                }
+            }
             Message::ResizeDebounce => {
                 if self.resize_debounce_seq != self.resize_debounce_spawned_seq {
                     // New resizes arrived during the wait -> restart timer
@@ -286,8 +294,7 @@ impl App {
         if self.show_shell_picker {
             match key {
                 Key::Named(Named::Escape) => {
-                    self.show_shell_picker = false;
-                    self.shell_picker_selected = 0;
+                    return self.update(Message::CloseShellPicker);
                 }
                 Key::Named(Named::ArrowUp) => {
                     self.shift_shell_picker_selection(-1);

--- a/src/gui/app/update/tab.rs
+++ b/src/gui/app/update/tab.rs
@@ -88,11 +88,7 @@ impl App {
         let action = ShortcutAction::resolve(key, modifiers, &self.config.shortcuts)?;
 
         match action {
-            ShortcutAction::NewTab => {
-                self.show_shell_picker = true;
-                self.shell_picker_selected = 0;
-                Some(Task::none())
-            }
+            ShortcutAction::NewTab => Some(self.update(Message::OpenShellPicker)),
             ShortcutAction::CloseTab => {
                 self.close_active_target();
                 Some(Task::none())

--- a/src/gui/app/view/shell_picker.rs
+++ b/src/gui/app/view/shell_picker.rs
@@ -1,7 +1,8 @@
 use super::super::{App, Message};
 use crate::gui::tab::ShellKind;
 use crate::gui::theme::{Palette, RADIUS_NORMAL, RADIUS_SMALL, SPACING_SMALL};
-use iced::widget::{button, center, column, container, mouse_area, stack, text};
+use iced::time::Instant;
+use iced::widget::{button, column, container, mouse_area, stack, text};
 use iced::{Background, Border, Color, Element, Length};
 
 const PICKER_WIDTH: f32 = 280.0;
@@ -12,17 +13,22 @@ impl App {
         base_layout: impl Into<Element<'a, Message>>,
     ) -> Element<'a, Message> {
         let palette = Palette::DARK;
+        let now = Instant::now();
+
+        let progress: f32 = self.shell_picker_anim.interpolate(0.0f32, 1.0f32, now);
+
+        let backdrop_alpha = 0.5 * progress;
 
         let backdrop = mouse_area(
             container(text(""))
                 .width(Length::Fill)
                 .height(Length::Fill)
-                .style(|_theme: &iced::Theme| container::Style {
+                .style(move |_theme: &iced::Theme| container::Style {
                     background: Some(Background::Color(Color {
                         r: 0.0,
                         g: 0.0,
                         b: 0.0,
-                        a: 0.4,
+                        a: backdrop_alpha,
                     })),
                     ..Default::default()
                 }),
@@ -36,13 +42,16 @@ impl App {
         items.push(
             text("Start New Session")
                 .size(15)
-                .color(palette.text)
+                .color(Color {
+                    a: progress,
+                    ..palette.text
+                })
                 .into(),
         );
-        items.push(divider());
+        items.push(divider_with_alpha(progress));
 
         // Shell section
-        items.push(section_label("Shells"));
+        items.push(section_label("Shells", progress));
 
         for shell in &self.available_shells {
             let label = shell.display_name();
@@ -57,14 +66,15 @@ impl App {
                 subtitle,
                 selected,
                 Message::CreateTab(shell.clone()),
+                progress,
             ));
             option_index += 1;
         }
 
         // SSH section
         if !self.config.ssh_profiles.is_empty() {
-            items.push(divider());
-            items.push(section_label("SSH"));
+            items.push(divider_with_alpha(progress));
+            items.push(section_label("SSH", progress));
 
             for (i, profile) in self.config.ssh_profiles.iter().enumerate() {
                 let label = if profile.name.is_empty() {
@@ -86,10 +96,14 @@ impl App {
                     subtitle,
                     selected,
                     Message::CreateSshTab(i),
+                    progress,
                 ));
                 option_index += 1;
             }
         }
+
+        let card_alpha = 0.98 * progress;
+        let border_alpha = 0.15 * progress;
 
         let popup_card = container(
             column(items)
@@ -102,20 +116,28 @@ impl App {
                 r: palette.surface.r * 0.9,
                 g: palette.surface.g * 0.9,
                 b: palette.surface.b * 0.9,
-                a: 0.98,
+                a: card_alpha,
             })),
             border: Border {
                 radius: (RADIUS_NORMAL + 4.0).into(),
                 width: 1.0,
                 color: Color {
-                    a: 0.15,
+                    a: border_alpha,
                     ..palette.text
                 },
             },
             ..Default::default()
         });
 
-        let centered_popup = center(popup_card).width(Length::Fill).height(Length::Fill);
+        // Slide up: start 16px below center, ease to 0
+        let slide_offset = 16.0 * (1.0 - progress);
+        let centered_popup: Element<Message> = container(popup_card)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x(Length::Fill)
+            .center_y(Length::Fill)
+            .padding(iced::Padding::new(0.0).top(slide_offset))
+            .into();
 
         stack![base_layout.into(), backdrop, centered_popup]
             .width(Length::Fill)
@@ -124,19 +146,25 @@ impl App {
     }
 }
 
-fn section_label(label: &str) -> Element<'_, Message> {
+fn section_label(label: &str, alpha: f32) -> Element<'_, Message> {
     let palette = Palette::DARK;
-    text(label).size(11).color(palette.text_secondary).into()
+    text(label)
+        .size(11)
+        .color(Color {
+            a: alpha * 0.7,
+            ..palette.text_secondary
+        })
+        .into()
 }
 
-fn divider() -> Element<'static, Message> {
+fn divider_with_alpha(alpha: f32) -> Element<'static, Message> {
     let palette = Palette::DARK;
     container(text(""))
         .width(Length::Fill)
         .height(1)
         .style(move |_theme: &iced::Theme| container::Style {
             background: Some(Background::Color(Color {
-                a: 0.1,
+                a: 0.1 * alpha,
                 ..palette.text
             })),
             ..Default::default()
@@ -149,6 +177,7 @@ fn picker_item(
     subtitle: Option<String>,
     selected: bool,
     on_press: Message,
+    alpha: f32,
 ) -> Element<'static, Message> {
     let palette = Palette::DARK;
 
@@ -156,9 +185,15 @@ fn picker_item(
         text(label)
             .size(13)
             .color(if selected {
-                palette.background
+                Color {
+                    a: alpha,
+                    ..palette.background
+                }
             } else {
-                palette.text
+                Color {
+                    a: alpha,
+                    ..palette.text
+                }
             })
             .into(),
     ];
@@ -169,11 +204,14 @@ fn picker_item(
                 .size(10)
                 .color(if selected {
                     Color {
-                        a: 0.7,
+                        a: 0.7 * alpha,
                         ..palette.background
                     }
                 } else {
-                    palette.text_secondary
+                    Color {
+                        a: alpha * 0.7,
+                        ..palette.text_secondary
+                    }
                 })
                 .into(),
         );
@@ -187,34 +225,43 @@ fn picker_item(
                 let hovered = matches!(status, iced::widget::button::Status::Hovered);
                 if selected {
                     iced::widget::button::Style {
-                        background: Some(Background::Color(palette.accent)),
-                        text_color: palette.background,
+                        background: Some(Background::Color(Color {
+                            a: alpha,
+                            ..palette.accent
+                        })),
+                        text_color: Color {
+                            a: alpha,
+                            ..palette.background
+                        },
                         border: Border {
                             radius: RADIUS_SMALL.into(),
                             width: 0.0,
                             color: Color::TRANSPARENT,
                         },
                         shadow: iced::Shadow::default(),
-                        snap: true,
+                        snap: false,
                     }
                 } else {
                     iced::widget::button::Style {
                         background: Some(Background::Color(if hovered {
                             Color {
-                                a: 0.08,
+                                a: 0.08 * alpha,
                                 ..palette.text
                             }
                         } else {
                             Color::TRANSPARENT
                         })),
-                        text_color: palette.text,
+                        text_color: Color {
+                            a: alpha,
+                            ..palette.text
+                        },
                         border: Border {
                             radius: RADIUS_SMALL.into(),
                             width: 0.0,
                             color: Color::TRANSPARENT,
                         },
                         shadow: iced::Shadow::default(),
-                        snap: true,
+                        snap: false,
                     }
                 }
             },

--- a/src/gui/components/button.rs
+++ b/src/gui/components/button.rs
@@ -1,96 +1,92 @@
-use crate::gui::theme::{Palette, RADIUS_NORMAL};
+use crate::gui::theme::Palette;
 use iced::widget::button;
-use iced::{Background, Border, Color, Theme};
+use iced::{Background, Border, Color, Shadow, Theme};
+
+const RADIUS: f32 = 6.0;
 
 pub fn primary(text: &str) -> button::Button<'_, crate::gui::app::Message> {
-    button(text).style(|_theme: &Theme, status: button::Status| {
-        let palette = Palette::DARK;
-        let base = button::Style {
-            background: Some(Background::Color(palette.accent)),
-            text_color: palette.background,
-            border: Border {
-                radius: RADIUS_NORMAL.into(),
-                width: 0.0,
-                color: Color::TRANSPARENT,
-            },
-            shadow: iced::Shadow::default(),
-            snap: true,
-        };
-
-        match status {
-            button::Status::Active => base,
-            button::Status::Hovered => button::Style {
-                background: Some(Background::Color(Color {
-                    a: 0.9,
+    button(iced::widget::text(text).size(13))
+        .padding([7, 16])
+        .style(|_theme: &Theme, status: button::Status| {
+            let palette = Palette::DARK;
+            let bg = match status {
+                button::Status::Hovered => Color {
+                    r: palette.accent.r * 1.1,
+                    g: palette.accent.g * 1.1,
+                    b: palette.accent.b * 1.1,
+                    a: 1.0,
+                },
+                button::Status::Pressed => Color {
+                    a: 0.85,
                     ..palette.accent
-                })),
-                ..base
-            },
-            button::Status::Pressed => button::Style {
-                background: Some(Background::Color(Color {
-                    a: 0.8,
-                    ..palette.accent
-                })),
-                ..base
-            },
-            button::Status::Disabled => button::Style {
-                background: Some(Background::Color(palette.surface)),
-                text_color: palette.text_secondary,
-                ..base
-            },
-        }
-    })
+                },
+                button::Status::Disabled => palette.surface,
+                _ => palette.accent,
+            };
+            let text_color = match status {
+                button::Status::Disabled => palette.text_secondary,
+                _ => palette.background,
+            };
+            button::Style {
+                background: Some(Background::Color(bg)),
+                text_color,
+                border: Border {
+                    radius: RADIUS.into(),
+                    width: 0.0,
+                    color: Color::TRANSPARENT,
+                },
+                shadow: Shadow::default(),
+                snap: true,
+            }
+        })
 }
 
 pub fn secondary(text: &str) -> button::Button<'_, crate::gui::app::Message> {
-    button(text).style(|_theme: &Theme, status: button::Status| {
-        let palette = Palette::DARK;
-        let base = button::Style {
-            background: Some(Background::Color(palette.surface)),
-            text_color: palette.text,
-            border: Border {
-                radius: RADIUS_NORMAL.into(),
-                width: 1.0,
-                color: Color {
-                    a: 0.1,
-                    ..palette.text
-                },
-            },
-            shadow: iced::Shadow::default(),
-            snap: true,
-        };
-
-        match status {
-            button::Status::Active => base,
-            button::Status::Hovered => button::Style {
-                background: Some(Background::Color(Color {
-                    a: 0.8, // Slightly lighter/transparent
-                    ..palette.surface
-                })),
-                border: Border {
-                    color: Color {
-                        a: 0.3,
+    button(iced::widget::text(text).size(13))
+        .padding([7, 16])
+        .style(|_theme: &Theme, status: button::Status| {
+            let palette = Palette::DARK;
+            let (bg, border_alpha) = match status {
+                button::Status::Hovered => (
+                    Color {
+                        a: 0.12,
                         ..palette.text
                     },
-                    ..base.border
+                    0.2,
+                ),
+                button::Status::Pressed => (
+                    Color {
+                        a: 0.08,
+                        ..palette.text
+                    },
+                    0.25,
+                ),
+                button::Status::Disabled => (
+                    Color {
+                        a: 0.04,
+                        ..palette.text
+                    },
+                    0.05,
+                ),
+                _ => (Color::TRANSPARENT, 0.1),
+            };
+            let text_color = match status {
+                button::Status::Disabled => palette.text_secondary,
+                _ => palette.text,
+            };
+            button::Style {
+                background: Some(Background::Color(bg)),
+                text_color,
+                border: Border {
+                    radius: RADIUS.into(),
+                    width: 1.0,
+                    color: Color {
+                        a: border_alpha,
+                        ..palette.text
+                    },
                 },
-                ..base
-            },
-            button::Status::Pressed => button::Style {
-                background: Some(Background::Color(Color {
-                    a: 0.6,
-                    ..palette.surface
-                })),
-                ..base
-            },
-            button::Status::Disabled => button::Style {
-                text_color: palette.text_secondary,
-                background: Some(Background::Color(Color {
-                    a: 0.5,
-                    ..palette.surface
-                })),
-                ..base
-            },
-        }
-    })
+                shadow: Shadow::default(),
+                snap: true,
+            }
+        })
 }

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -6,7 +6,7 @@ use iced::widget::{button, container, row, scrollable, text};
 use iced::{Background, Border, Color, Element, Length, Theme};
 
 pub fn tab_bar<'a>(
-    tabs: impl Iterator<Item = (&'a str, usize, bool)>, // (title, index, is_active)
+    tabs: impl Iterator<Item = (&'a str, usize, bool)>,
     on_add: Message,
     on_settings: Message,
     bar_alpha: f32,
@@ -21,25 +21,35 @@ pub fn tab_bar<'a>(
         tab_elements.push(tab_item);
     }
 
-    let add_btn = button(text("+").size(14))
-        .on_press(on_add)
-        .padding([4, 7])
-        .style(
-            move |_theme: &Theme, status: button::Status| button::Style {
-                background: Some(Background::Color(Color::TRANSPARENT)),
-                text_color: match status {
-                    button::Status::Hovered => palette.text,
-                    _ => palette.text_secondary,
-                },
-                border: Border {
-                    radius: 6.0.into(),
-                    width: 0.0,
-                    color: Color::TRANSPARENT,
-                },
-                shadow: iced::Shadow::default(),
-                snap: true,
+    let icon_style = move |_theme: &Theme, status: button::Status| button::Style {
+        background: Some(Background::Color(match status {
+            button::Status::Hovered => Color {
+                a: 0.1,
+                ..palette.text
             },
-        );
+            _ => Color::TRANSPARENT,
+        })),
+        text_color: match status {
+            button::Status::Hovered => palette.text,
+            _ => palette.text_secondary,
+        },
+        border: Border {
+            radius: 6.0.into(),
+            width: 0.0,
+            color: Color::TRANSPARENT,
+        },
+        shadow: iced::Shadow::default(),
+        snap: true,
+    };
+
+    let add_btn = button(text("+").size(13))
+        .on_press(on_add)
+        .padding([6, 10])
+        .style(icon_style);
+    let settings_btn = button(text("⚙").size(13))
+        .on_press(on_settings)
+        .padding([6, 10])
+        .style(icon_style);
 
     let tabs_row = row(tab_elements)
         .spacing(2)
@@ -56,26 +66,6 @@ pub fn tab_bar<'a>(
         .width(Length::Fill)
         .height(Length::Shrink);
 
-    let settings_btn = button(text("⚙").size(12))
-        .on_press(on_settings)
-        .padding([4, 7])
-        .style(
-            move |_theme: &Theme, status: button::Status| button::Style {
-                background: Some(Background::Color(Color::TRANSPARENT)),
-                text_color: match status {
-                    button::Status::Hovered => palette.text,
-                    _ => palette.text_secondary,
-                },
-                border: Border {
-                    radius: 6.0.into(),
-                    width: 0.0,
-                    color: Color::TRANSPARENT,
-                },
-                shadow: iced::Shadow::default(),
-                snap: true,
-            },
-        );
-
     // macOS: left control buttons
     #[cfg(target_os = "macos")]
     let left_padding = 80.0;
@@ -87,78 +77,43 @@ pub fn tab_bar<'a>(
     // Windows: right control buttons
     #[cfg(target_os = "windows")]
     let window_controls = {
-        let minimize_btn = button(text("─").size(12))
-            .on_press(Message::WindowMinimize)
-            .padding([6, 12])
-            .style(
-                move |_theme: &Theme, status: button::Status| button::Style {
-                    background: match status {
-                        button::Status::Hovered => Some(Background::Color(Color {
-                            a: 0.2,
-                            ..palette.text
-                        })),
-                        _ => Some(Background::Color(Color::TRANSPARENT)),
+        let win_btn = |label: &str, msg: Message, hover_color: Color| {
+            button(text(label).size(12))
+                .on_press(msg)
+                .padding([6, 12])
+                .style(
+                    move |_theme: &Theme, status: button::Status| button::Style {
+                        background: match status {
+                            button::Status::Hovered => Some(Background::Color(hover_color)),
+                            _ => Some(Background::Color(Color::TRANSPARENT)),
+                        },
+                        text_color: match status {
+                            button::Status::Hovered => Color::WHITE,
+                            _ => palette.text_secondary,
+                        },
+                        border: Border {
+                            radius: 0.0.into(),
+                            width: 0.0,
+                            color: Color::TRANSPARENT,
+                        },
+                        shadow: iced::Shadow::default(),
+                        snap: true,
                     },
-                    text_color: palette.text_secondary,
-                    border: Border {
-                        radius: 0.0.into(),
-                        width: 0.0,
-                        color: Color::TRANSPARENT,
-                    },
-                    shadow: iced::Shadow::default(),
-                    snap: true,
-                },
-            );
+                )
+        };
 
-        let maximize_btn = button(text("□").size(12))
-            .on_press(Message::WindowMaximize)
-            .padding([6, 12])
-            .style(
-                move |_theme: &Theme, status: button::Status| button::Style {
-                    background: match status {
-                        button::Status::Hovered => Some(Background::Color(Color {
-                            a: 0.2,
-                            ..palette.text
-                        })),
-                        _ => Some(Background::Color(Color::TRANSPARENT)),
-                    },
-                    text_color: palette.text_secondary,
-                    border: Border {
-                        radius: 0.0.into(),
-                        width: 0.0,
-                        color: Color::TRANSPARENT,
-                    },
-                    shadow: iced::Shadow::default(),
-                    snap: true,
-                },
-            );
+        let hover_subtle = Color {
+            a: 0.15,
+            ..palette.text
+        };
+        let hover_close = Color::from_rgb(0.9, 0.2, 0.2);
 
-        let close_btn = button(text("✕").size(12))
-            .on_press(Message::Exit)
-            .padding([6, 12])
-            .style(
-                move |_theme: &Theme, status: button::Status| button::Style {
-                    background: match status {
-                        button::Status::Hovered => {
-                            Some(Background::Color(Color::from_rgb(0.9, 0.2, 0.2)))
-                        }
-                        _ => Some(Background::Color(Color::TRANSPARENT)),
-                    },
-                    text_color: match status {
-                        button::Status::Hovered => Color::WHITE,
-                        _ => palette.text_secondary,
-                    },
-                    border: Border {
-                        radius: 0.0.into(),
-                        width: 0.0,
-                        color: Color::TRANSPARENT,
-                    },
-                    shadow: iced::Shadow::default(),
-                    snap: true,
-                },
-            );
-
-        row![minimize_btn, maximize_btn, close_btn].spacing(0)
+        row![
+            win_btn("─", Message::WindowMinimize, hover_subtle),
+            win_btn("□", Message::WindowMaximize, hover_subtle),
+            win_btn("✕", Message::Exit, hover_close),
+        ]
+        .spacing(0)
     };
 
     #[cfg(target_os = "windows")]
@@ -178,12 +133,16 @@ pub fn tab_bar<'a>(
                 a: bar_alpha,
                 ..palette.surface
             })),
+            border: Border {
+                radius: 0.0.into(),
+                width: 0.0,
+                color: Color::TRANSPARENT,
+            },
             ..Default::default()
         })
         .padding(padding)
         .width(Length::Fill);
 
-    // Windows: Enable window dragging by clicking on the tab bar background
     #[cfg(target_os = "windows")]
     return mouse_area(tab_bar_container)
         .on_press(Message::WindowDrag)
@@ -208,21 +167,27 @@ fn browser_tab<'a>(
     } else {
         title.into()
     };
-    let tab_text = text(display_title).size(13);
+    let tab_text = text(display_title).size(12);
 
-    let close_btn = button(text("✕").size(10))
+    let close_btn = button(text("✕").size(9))
         .on_press(Message::CloseTab(index))
-        .padding([2, 4])
+        .padding([2, 5])
         .style(
             move |_theme: &Theme, status: button::Status| button::Style {
                 background: match status {
                     button::Status::Hovered => Some(Background::Color(Color {
-                        a: 0.2,
+                        a: 0.15,
                         ..palette.text
                     })),
                     _ => Some(Background::Color(Color::TRANSPARENT)),
                 },
-                text_color: palette.text_secondary,
+                text_color: match status {
+                    button::Status::Hovered => palette.text,
+                    _ => Color {
+                        a: 0.5,
+                        ..palette.text_secondary
+                    },
+                },
                 border: Border {
                     radius: 4.0.into(),
                     width: 0.0,
@@ -234,44 +199,63 @@ fn browser_tab<'a>(
         );
 
     let tab_content = row![tab_text, close_btn]
-        .spacing(8)
+        .spacing(6)
         .align_y(iced::Alignment::Center);
 
     let inactive_alpha = tab_alpha.clamp(0.0, 1.0);
-    let hover_alpha = (inactive_alpha + 0.15).min(1.0);
     let tab_button = button(tab_content)
         .on_press(Message::TabSelected(index))
-        .padding([8, 12])
+        .padding([6, 12])
         .style(move |_theme: &Theme, status: button::Status| {
-            let (bg_color, text_color) = if is_active {
-                (
-                    Color {
+            if is_active {
+                button::Style {
+                    background: Some(Background::Color(Color {
                         a: inactive_alpha,
                         ..palette.background
-                    },
-                    palette.text,
-                )
+                    })),
+                    text_color: palette.text,
+                    border: Border::default(),
+                    shadow: iced::Shadow::default(),
+                    snap: false,
+                }
             } else {
-                let hover_bg = match status {
-                    button::Status::Hovered => Color {
-                        a: hover_alpha,
-                        ..palette.background
+                let hovered = matches!(status, button::Status::Hovered);
+                button::Style {
+                    background: Some(Background::Color(if hovered {
+                        Color {
+                            a: 0.08,
+                            ..palette.text
+                        }
+                    } else {
+                        Color::TRANSPARENT
+                    })),
+                    text_color: if hovered {
+                        palette.text
+                    } else {
+                        palette.text_secondary
                     },
-                    _ => Color {
-                        a: inactive_alpha,
-                        ..palette.background
-                    },
-                };
-                (hover_bg, palette.text_secondary)
-            };
-
-            button::Style {
-                background: Some(Background::Color(bg_color)),
-                text_color,
-                shadow: iced::Shadow::default(),
-                ..Default::default()
+                    border: Border::default(),
+                    shadow: iced::Shadow::default(),
+                    snap: false,
+                }
             }
         });
 
-    tab_button.into()
+    if is_active {
+        // Active tab with bottom accent indicator
+        let indicator =
+            container(text(""))
+                .width(Length::Fill)
+                .height(2)
+                .style(move |_theme: &Theme| container::Style {
+                    background: Some(Background::Color(palette.accent)),
+                    ..Default::default()
+                });
+
+        iced::widget::column![tab_button, indicator]
+            .width(Length::Shrink)
+            .into()
+    } else {
+        tab_button.into()
+    }
 }

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -77,41 +77,41 @@ pub fn tab_bar<'a>(
     // Windows: right control buttons
     #[cfg(target_os = "windows")]
     let window_controls = {
-        let win_btn = |label: &str, msg: Message, hover_color: Color| {
-            button(text(label).size(12))
-                .on_press(msg)
-                .padding([6, 12])
-                .style(
-                    move |_theme: &Theme, status: button::Status| button::Style {
-                        background: match status {
-                            button::Status::Hovered => Some(Background::Color(hover_color)),
-                            _ => Some(Background::Color(Color::TRANSPARENT)),
-                        },
-                        text_color: match status {
-                            button::Status::Hovered => Color::WHITE,
-                            _ => palette.text_secondary,
-                        },
-                        border: Border {
-                            radius: 0.0.into(),
-                            width: 0.0,
-                            color: Color::TRANSPARENT,
-                        },
-                        shadow: iced::Shadow::default(),
-                        snap: true,
-                    },
-                )
-        };
-
         let hover_subtle = Color {
             a: 0.15,
             ..palette.text
         };
         let hover_close = Color::from_rgb(0.9, 0.2, 0.2);
 
+        let win_style = move |hover_color: Color| {
+            move |_theme: &Theme, status: button::Status| button::Style {
+                background: match status {
+                    button::Status::Hovered => Some(Background::Color(hover_color)),
+                    _ => Some(Background::Color(Color::TRANSPARENT)),
+                },
+                text_color: match status {
+                    button::Status::Hovered => Color::WHITE,
+                    _ => palette.text_secondary,
+                },
+                border: Border::default(),
+                shadow: iced::Shadow::default(),
+                snap: true,
+            }
+        };
+
         row![
-            win_btn("─", Message::WindowMinimize, hover_subtle),
-            win_btn("□", Message::WindowMaximize, hover_subtle),
-            win_btn("✕", Message::Exit, hover_close),
+            button(text("─").size(12))
+                .on_press(Message::WindowMinimize)
+                .padding([6, 12])
+                .style(win_style(hover_subtle)),
+            button(text("□").size(12))
+                .on_press(Message::WindowMaximize)
+                .padding([6, 12])
+                .style(win_style(hover_subtle)),
+            button(text("✕").size(12))
+                .on_press(Message::Exit)
+                .padding([6, 12])
+                .style(win_style(hover_close)),
         ]
         .spacing(0)
     };


### PR DESCRIPTION
Closes #48

## Changes
- Shell picker open/close animation (`iced::Animation`, 250ms EaseOutQuint)
- Tab bar redesign: active tab indicator, cleaner hover states
- Button style refresh: rounded corners, subtle hover feedback