### PR TITLE
fix: SSH sessions missing color support

### DIFF
--- a/src/gui/tab.rs
+++ b/src/gui/tab.rs
@@ -395,7 +395,7 @@ impl SshProfile {
         LaunchSpec {
             program: "ssh".to_string(),
             args,
-            env: vec![],
+            env: vec![("TERM".to_string(), "xterm-256color".to_string())],
             rows: size.lines as u16,
             cols: size.columns as u16,
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -78,6 +78,15 @@ impl Session {
     ) -> Result<Self, SessionError> {
         tty::setup_env();
 
+        // Override process env for keys specified by the launch spec
+        // (e.g. TERM=xterm-256color for SSH). This ensures the forked
+        // child inherits the correct value even if setup_env set something
+        // else. The Options.env also applies, giving a double guarantee.
+        for (key, value) in &spec.env {
+            // SAFETY: no other threads mutate env concurrently on the main thread.
+            unsafe { std::env::set_var(key, value) };
+        }
+
         let options = Options {
             shell: Some(Shell::new(spec.program, spec.args)),
             env: spec.env.into_iter().collect(),


### PR DESCRIPTION
## Summary

- SSH sessions lacked color because `TERM=alacritty` (set by `tty::setup_env()`) is not recognized by most remote servers
- Set `TERM=xterm-256color` in the SSH launch spec env, and override the process env before fork so the child PTY inherits it

## Test plan

- [x] Open an SSH tab and verify colors work (`ls --color`, vim syntax highlighting, etc.)
- [x] Verify local shell tabs are unaffected

Resolves #54