### PR TITLE
feat: tab drag-and-drop reordering

### DIFF
--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -21,6 +21,8 @@ pub(super) const SETTINGS_TAB_INDEX: usize = usize::MAX;
 #[derive(Clone)]
 pub enum Message {
     TabSelected(usize),
+    TabDragHover(usize),
+    TabDragRelease,
     CloseTab(usize),
     OpenShellPicker,
     CloseShellPicker,
@@ -80,7 +82,7 @@ pub enum Message {
     WindowMinimize,
     #[cfg(target_os = "windows")]
     WindowMaximize,
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     WindowDrag,
     Exit,
 }
@@ -103,6 +105,8 @@ pub struct App {
     pub(super) next_tab_id: u64,
     pub(super) tab_bar_scroll_x: f32,
     pub(super) ignore_scrollable_sync: bool,
+    pub(super) dragging_tab: Option<usize>,
+    pub(super) drag_target: Option<usize>,
     pub(super) scroll_accumulator: f32,
     pub(super) resize_debounce_pending: bool,
     pub(super) resize_debounce_seq: u64,
@@ -144,6 +148,8 @@ impl App {
             next_tab_id: 1,
             tab_bar_scroll_x: 0.0,
             ignore_scrollable_sync: false,
+            dragging_tab: None,
+            drag_target: None,
             scroll_accumulator: 0.0,
             resize_debounce_pending: false,
             resize_debounce_seq: 0,

--- a/src/gui/app/subscription.rs
+++ b/src/gui/app/subscription.rs
@@ -56,6 +56,9 @@ impl App {
                     modifiers,
                     text: text.map(|s| s.to_string()),
                 }),
+                Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                    Some(Message::TabDragRelease)
+                }
                 Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
                     let (lines_y, pixels_x) = match delta {
                         mouse::ScrollDelta::Lines { x, y } => (y, x * 30.0),

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -24,7 +24,30 @@ impl App {
                     self.active_tab = SETTINGS_TAB_INDEX;
                 } else if index < self.tabs.len() {
                     self.active_tab = index;
+                    self.dragging_tab = Some(index);
+                    self.drag_target = None;
                 }
+            }
+            Message::TabDragHover(index) => {
+                if self.dragging_tab.is_some() && index < self.tabs.len() {
+                    self.drag_target = Some(index);
+                }
+            }
+            Message::TabDragRelease => {
+                if let Some(from) = self.dragging_tab.take()
+                    && let Some(target) = self.drag_target.take()
+                        && from != target && from < self.tabs.len() && target < self.tabs.len() {
+                            let tab = self.tabs.remove(from);
+                            self.tabs.insert(target, tab);
+                            if self.active_tab == from {
+                                self.active_tab = target;
+                            } else if from < self.active_tab && target >= self.active_tab {
+                                self.active_tab -= 1;
+                            } else if from > self.active_tab && target <= self.active_tab {
+                                self.active_tab += 1;
+                            }
+                        }
+                self.drag_target = None;
             }
             Message::CloseTab(index) => {
                 self.handle_close_tab(index);
@@ -276,7 +299,7 @@ impl App {
             Message::WindowMaximize => {
                 return iced::window::latest().and_then(iced::window::toggle_maximize);
             }
-            #[cfg(target_os = "windows")]
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
             Message::WindowDrag => {
                 return iced::window::latest().and_then(iced::window::drag);
             }

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -36,17 +36,20 @@ impl App {
             Message::TabDragRelease => {
                 if let Some(from) = self.dragging_tab.take()
                     && let Some(target) = self.drag_target.take()
-                        && from != target && from < self.tabs.len() && target < self.tabs.len() {
-                            let tab = self.tabs.remove(from);
-                            self.tabs.insert(target, tab);
-                            if self.active_tab == from {
-                                self.active_tab = target;
-                            } else if from < self.active_tab && target >= self.active_tab {
-                                self.active_tab -= 1;
-                            } else if from > self.active_tab && target <= self.active_tab {
-                                self.active_tab += 1;
-                            }
-                        }
+                    && from != target
+                    && from < self.tabs.len()
+                    && target < self.tabs.len()
+                {
+                    let tab = self.tabs.remove(from);
+                    self.tabs.insert(target, tab);
+                    if self.active_tab == from {
+                        self.active_tab = target;
+                    } else if from < self.active_tab && target >= self.active_tab {
+                        self.active_tab -= 1;
+                    } else if from > self.active_tab && target <= self.active_tab {
+                        self.active_tab += 1;
+                    }
+                }
                 self.drag_target = None;
             }
             Message::CloseTab(index) => {

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -45,6 +45,8 @@ impl App {
             Message::OpenSettingsTab,
             bar_alpha,
             tab_alpha,
+            self.dragging_tab,
+            self.drag_target,
         );
 
         let main_content: Element<Message> = if self.active_tab == SETTINGS_TAB_INDEX {

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -10,13 +10,34 @@ pub fn tab_bar<'a>(
     on_settings: Message,
     bar_alpha: f32,
     tab_alpha: f32,
+    dragging_tab: Option<usize>,
+    drag_target: Option<usize>,
 ) -> Element<'a, Message> {
     let palette = Palette::DARK;
 
+    let tabs_data: Vec<_> = tabs.collect();
+
+    // Compute visual display order: preview the reorder during drag
+    let display_order: Vec<usize> = if let (Some(from), Some(target)) = (dragging_tab, drag_target)
+    {
+        if from != target && from < tabs_data.len() && target < tabs_data.len() {
+            let mut order: Vec<usize> = (0..tabs_data.len()).collect();
+            let dragged = order.remove(from);
+            order.insert(target, dragged);
+            order
+        } else {
+            (0..tabs_data.len()).collect()
+        }
+    } else {
+        (0..tabs_data.len()).collect()
+    };
+
     let mut tab_elements: Vec<Element<Message>> = Vec::new();
 
-    for (title, index, is_active) in tabs {
-        let tab_item = browser_tab(title, index, is_active, tab_alpha);
+    for &orig_idx in &display_order {
+        let (title, index, is_active) = tabs_data[orig_idx];
+        let is_dragging = dragging_tab == Some(index);
+        let tab_item = browser_tab(title, index, is_active, tab_alpha, is_dragging);
         let tab_item = mouse_area(tab_item)
             .on_press(Message::TabSelected(index))
             .on_enter(Message::TabDragHover(index))
@@ -160,6 +181,7 @@ fn browser_tab<'a>(
     index: usize,
     is_active: bool,
     tab_alpha: f32,
+    is_dragging: bool,
 ) -> Element<'a, Message> {
     let palette = Palette::DARK;
 
@@ -208,7 +230,25 @@ fn browser_tab<'a>(
     let inactive_alpha = tab_alpha.clamp(0.0, 1.0);
     let tab_button = button(tab_content).padding([6, 12]).style(
         move |_theme: &Theme, status: button::Status| {
-            if is_active {
+            if is_dragging {
+                button::Style {
+                    background: Some(Background::Color(Color {
+                        a: 0.15,
+                        ..palette.accent
+                    })),
+                    text_color: palette.text,
+                    border: Border {
+                        radius: 4.0.into(),
+                        width: 1.0,
+                        color: Color {
+                            a: 0.5,
+                            ..palette.accent
+                        },
+                    },
+                    shadow: iced::Shadow::default(),
+                    snap: false,
+                }
+            } else if is_active {
                 button::Style {
                     background: Some(Background::Color(Color {
                         a: inactive_alpha,

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -1,6 +1,5 @@
 use crate::gui::app::Message;
 use crate::gui::theme::Palette;
-#[cfg(target_os = "windows")]
 use iced::widget::mouse_area;
 use iced::widget::{button, container, row, scrollable, text};
 use iced::{Background, Border, Color, Element, Length, Theme};
@@ -18,6 +17,10 @@ pub fn tab_bar<'a>(
 
     for (title, index, is_active) in tabs {
         let tab_item = browser_tab(title, index, is_active, tab_alpha);
+        let tab_item = mouse_area(tab_item)
+            .on_press(Message::TabSelected(index))
+            .on_enter(Message::TabDragHover(index))
+            .into();
         tab_elements.push(tab_item);
     }
 
@@ -143,12 +146,12 @@ pub fn tab_bar<'a>(
         .padding(padding)
         .width(Length::Fill);
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     return mouse_area(tab_bar_container)
         .on_press(Message::WindowDrag)
         .into();
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     tab_bar_container.into()
 }
 
@@ -203,10 +206,8 @@ fn browser_tab<'a>(
         .align_y(iced::Alignment::Center);
 
     let inactive_alpha = tab_alpha.clamp(0.0, 1.0);
-    let tab_button = button(tab_content)
-        .on_press(Message::TabSelected(index))
-        .padding([6, 12])
-        .style(move |_theme: &Theme, status: button::Status| {
+    let tab_button = button(tab_content).padding([6, 12]).style(
+        move |_theme: &Theme, status: button::Status| {
             if is_active {
                 button::Style {
                     background: Some(Background::Color(Color {
@@ -239,7 +240,8 @@ fn browser_tab<'a>(
                     snap: false,
                 }
             }
-        });
+        },
+    );
 
     if is_active {
         // Active tab with bottom accent indicator

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -293,13 +293,12 @@ fn compute_display_order(
     dragging_tab: Option<usize>,
     drag_target: Option<usize>,
 ) -> Vec<usize> {
-    if let (Some(from), Some(target)) = (dragging_tab, drag_target) {
-        if from != target && from < len && target < len {
+    if let (Some(from), Some(target)) = (dragging_tab, drag_target)
+        && from != target && from < len && target < len {
             let mut order: Vec<usize> = (0..len).collect();
             let dragged = order.remove(from);
             order.insert(target, dragged);
             return order;
         }
-    }
     (0..len).collect()
 }

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -294,11 +294,14 @@ fn compute_display_order(
     drag_target: Option<usize>,
 ) -> Vec<usize> {
     if let (Some(from), Some(target)) = (dragging_tab, drag_target)
-        && from != target && from < len && target < len {
-            let mut order: Vec<usize> = (0..len).collect();
-            let dragged = order.remove(from);
-            order.insert(target, dragged);
-            return order;
-        }
+        && from != target
+        && from < len
+        && target < len
+    {
+        let mut order: Vec<usize> = (0..len).collect();
+        let dragged = order.remove(from);
+        order.insert(target, dragged);
+        return order;
+    }
     (0..len).collect()
 }

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -16,26 +16,12 @@ pub fn tab_bar<'a>(
     let palette = Palette::DARK;
 
     let tabs_data: Vec<_> = tabs.collect();
-
-    // Compute visual display order: preview the reorder during drag
-    let display_order: Vec<usize> = if let (Some(from), Some(target)) = (dragging_tab, drag_target)
-    {
-        if from != target && from < tabs_data.len() && target < tabs_data.len() {
-            let mut order: Vec<usize> = (0..tabs_data.len()).collect();
-            let dragged = order.remove(from);
-            order.insert(target, dragged);
-            order
-        } else {
-            (0..tabs_data.len()).collect()
-        }
-    } else {
-        (0..tabs_data.len()).collect()
-    };
+    let display_order = compute_display_order(tabs_data.len(), dragging_tab, drag_target);
 
     let mut tab_elements: Vec<Element<Message>> = Vec::new();
 
-    for &orig_idx in &display_order {
-        let (title, index, is_active) = tabs_data[orig_idx];
+    for &original_index in &display_order {
+        let (title, index, is_active) = tabs_data[original_index];
         let is_dragging = dragging_tab == Some(index);
         let tab_item = browser_tab(title, index, is_active, tab_alpha, is_dragging);
         let tab_item = mouse_area(tab_item)
@@ -300,4 +286,20 @@ fn browser_tab<'a>(
     } else {
         tab_button.into()
     }
+}
+
+fn compute_display_order(
+    len: usize,
+    dragging_tab: Option<usize>,
+    drag_target: Option<usize>,
+) -> Vec<usize> {
+    if let (Some(from), Some(target)) = (dragging_tab, drag_target) {
+        if from != target && from < len && target < len {
+            let mut order: Vec<usize> = (0..len).collect();
+            let dragged = order.remove(from);
+            order.insert(target, dragged);
+            return order;
+        }
+    }
+    (0..len).collect()
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -17,10 +17,6 @@ pub fn apply_style(handle: WindowHandle<'_>, theme: &ThemeConfig) {
 }
 
 fn apply_style_inner(handle: WindowHandle<'_>, theme: &ThemeConfig) {
-    if !theme.blur_enabled {
-        return;
-    }
-
     let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
         return;
     };
@@ -29,6 +25,16 @@ fn apply_style_inner(handle: WindowHandle<'_>, theme: &ThemeConfig) {
     let Some(window) = view.window() else {
         return;
     };
+
+    // Prevent macOS from treating the title bar / content area as a drag
+    // handle.  We manage window dragging explicitly via iced's window::drag
+    // on the tab bar's empty space instead.
+    window.setMovable(false);
+    window.setMovableByWindowBackground(false);
+
+    if !theme.blur_enabled {
+        return;
+    }
 
     // Make window non opaque with clear background so blur shows through
     window.setOpaque(false);


### PR DESCRIPTION
Resolves #56

## Summary
- Implement tab drag-and-drop reordering with real-time visual preview
- Tabs shift in place during drag to show the target position
- Dragged tab is highlighted with accent border
- Fix macOS window drag intercepting tab drag (`setMovable(false)`)

## Test plan
- [x] Open multiple tabs
- [x] Drag a tab to a different position — other tabs should shift in real-time
- [x] Release to confirm the reorder
- [x] Verify active tab follows correctly after reorder
- [x] Verify window drag still works from empty tab bar area (macOS/Windows)