### PR TITLE
feat: tab index numbers + Cmd/Ctrl+1-9 navigation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -277,10 +277,6 @@ impl AppConfig {
                 config.apply_file(file);
             }
         }
-        // Load passwords from OS keychain
-        for profile in &mut config.ssh_profiles {
-            profile.password = crate::keychain::get_password(&profile.host, &profile.user);
-        }
         config
     }
 

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -3,7 +3,7 @@ mod tab;
 mod terminal;
 
 use super::{App, Message, SETTINGS_TAB_INDEX};
-use crate::gui::settings::{SettingsDraft, SettingsField};
+use crate::gui::settings::{SettingsCategory, SettingsDraft, SettingsField};
 use crate::gui::tab::ShellKind;
 use iced::keyboard::{Key, key::Named};
 use iced::time::Instant;
@@ -116,6 +116,10 @@ impl App {
                     self.settings_open = true;
                     self.active_tab = SETTINGS_TAB_INDEX;
                     self.settings_draft = SettingsDraft::from_config(&self.config);
+                }
+                if matches!(category, SettingsCategory::Ssh) {
+                    self.settings_draft
+                        .load_ssh_passwords_from_keychain(&self.config.ssh_profiles);
                 }
             }
             Message::SettingsInputChanged(field, value) => {
@@ -336,6 +340,24 @@ impl App {
                 _ => {}
             }
             return Task::none();
+        }
+
+        // Cmd+1..9 (macOS) / Ctrl+1..9 (other) — switch to Nth tab
+        if let Key::Character(ref c) = key
+            && let Some(digit) = c.chars().next().and_then(|ch| ch.to_digit(10))
+        {
+            #[cfg(target_os = "macos")]
+            let modifier_held = modifiers.logo();
+            #[cfg(not(target_os = "macos"))]
+            let modifier_held = modifiers.control();
+
+            if modifier_held && (1..=9).contains(&digit) {
+                let target = (digit as usize) - 1;
+                if target < self.tabs.len() {
+                    self.active_tab = target;
+                }
+                return Task::none();
+            }
         }
 
         if let Some(task) = self.handle_app_shortcut(&key, modifiers) {

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -194,6 +194,10 @@ fn browser_tab<'a>(
     } else {
         title.into()
     };
+    let index_label = text(format!("{}", index + 1)).size(10).color(Color {
+        a: 0.35,
+        ..palette.text_secondary
+    });
     let tab_text = text(display_title).size(12);
 
     let close_btn = button(text("✕").size(9))
@@ -225,7 +229,7 @@ fn browser_tab<'a>(
             },
         );
 
-    let tab_content = row![tab_text, close_btn]
+    let tab_content = row![index_label, tab_text, close_btn]
         .spacing(6)
         .align_y(iced::Alignment::Center);
 

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -202,6 +202,18 @@ impl SettingsDraft {
         }
     }
 
+    /// Load passwords from OS keychain into SSH profile drafts.
+    /// Call this only when the user opens SSH settings, not at app startup.
+    pub fn load_ssh_passwords_from_keychain(&mut self, profiles: &[SshProfile]) {
+        for (draft, profile) in self.ssh_profiles.iter_mut().zip(profiles.iter()) {
+            if draft.password.is_empty()
+                && let Some(pw) = crate::keychain::get_password(&profile.host, &profile.user)
+            {
+                draft.password = pw;
+            }
+        }
+    }
+
     pub fn update_ssh_profile(&mut self, index: usize, field: SshProfileField, value: String) {
         if let Some(draft) = self.ssh_profiles.get_mut(index) {
             match field {

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -101,7 +101,7 @@ fn send_status(output_tx: &mut futures_mpsc::UnboundedSender<OutputEvent>, tab_i
 
 // ── Main SSH task ───────────────────────────────────────────────────
 async fn ssh_task(
-    profile: SshProfile,
+    mut profile: SshProfile,
     tab_id: u64,
     rows: u16,
     cols: u16,
@@ -130,6 +130,11 @@ async fn ssh_task(
             ansi::bold(&format!("Connecting to {dest}{port_info}"))
         ),
     );
+
+    // Load password from OS keychain on demand (not at app startup)
+    if profile.password.is_none() && profile.identity_file.is_none() {
+        profile.password = crate::keychain::get_password(&profile.host, &profile.user);
+    }
 
     // Auth method hint
     if let Some(ref identity) = profile.identity_file {


### PR DESCRIPTION
## Summary
- Display tab index numbers (1, 2, 3...) with muted color on each tab
- Cmd+N (macOS) / Ctrl+N (Windows/Linux) to switch to Nth tab (1-9)
- Defer keychain access from app startup to SSH connection time / settings SSH tab only
- Remove redundant drag-active highlight style on tabs

## Test plan
- [x] Verify tab numbers display correctly
- [x] Test Cmd/Ctrl + 1~9 switches to correct tab
- [x] Confirm no keychain prompt on app startup
- [x] Keychain prompt only appears when opening SSH settings or connecting

Resolves #73