### PR TITLE
feat: dynamic UI palette & custom TOML themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,45 @@ Rabbitty is a terminal emulator chasing `foot`-like memory thrift and cross-plat
 - [ ] Easy file upload & download with SFTP
 - [ ] Split terminal in single tab
 
+## Custom Themes
+
+Rabbitty ships with built-in color schemes (Catppuccin Mocha, Dracula, Tokyo Night, Nord, One Dark, Gruvbox Dark, Solarized Dark) and supports user-defined themes via TOML files.
+
+### Adding a custom theme
+
+1. Create the themes directory:
+   ```
+   mkdir -p ~/.config/rabbitty/themes
+   ```
+2. Add a `.toml` file (e.g. `~/.config/rabbitty/themes/my-theme.toml`):
+   ```toml
+   name = "My Custom Theme"
+   foreground = "#c0caf5"
+   background = "#1a1b26"
+   cursor = "#c0caf5"
+
+   [ansi]
+   black = "#15161e"
+   red = "#f7768e"
+   green = "#9ece6a"
+   yellow = "#e0af68"
+   blue = "#7aa2f7"
+   magenta = "#bb9af7"
+   cyan = "#7dcfff"
+   white = "#a9b1d6"
+   bright_black = "#414868"
+   bright_red = "#f7768e"
+   bright_green = "#9ece6a"
+   bright_yellow = "#e0af68"
+   bright_blue = "#7aa2f7"
+   bright_magenta = "#bb9af7"
+   bright_cyan = "#7dcfff"
+   bright_white = "#c0caf5"
+   ```
+3. Restart Rabbitty — the theme appears in **Settings > Theme > Color Scheme**.
+
+A theme with the same name as a built-in will override it. See `assets/example-theme.toml` for a full reference.
+
 ## Supported Platforms
 
 - Linux (x86_64, aarch64)

--- a/assets/example-theme.toml
+++ b/assets/example-theme.toml
@@ -1,0 +1,26 @@
+# Example RabbiTTY theme file
+# Place .toml files in ~/.config/rabbitty/themes/ to add custom themes.
+# Themes with the same name as a built-in theme will override it.
+
+name = "My Custom Theme"
+foreground = "#c0caf5"
+background = "#1a1b26"
+cursor = "#c0caf5"
+
+[ansi]
+black = "#15161e"
+red = "#f7768e"
+green = "#9ece6a"
+yellow = "#e0af68"
+blue = "#7aa2f7"
+magenta = "#bb9af7"
+cyan = "#7dcfff"
+white = "#a9b1d6"
+bright_black = "#414868"
+bright_red = "#f7768e"
+bright_green = "#9ece6a"
+bright_yellow = "#e0af68"
+bright_blue = "#7aa2f7"
+bright_magenta = "#bb9af7"
+bright_cyan = "#7dcfff"
+bright_white = "#c0caf5"

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -112,6 +112,7 @@ pub struct App {
     pub(super) resize_debounce_seq: u64,
     pub(super) resize_debounce_spawned_seq: u64,
     pub(super) shell_picker_anim: Animation<bool>,
+    pub(super) palette: crate::gui::theme::Palette,
     pub(super) window_style_applied: bool,
     #[cfg(target_os = "macos")]
     pub(super) show_restart_confirm: bool,
@@ -123,6 +124,7 @@ pub struct App {
 
 impl App {
     pub fn new(config: AppConfig) -> Self {
+        let palette = crate::gui::theme::Palette::from_theme(&config.theme);
         let all_font_options = build_all_font_options(config.terminal.font_selection.as_deref());
         let show_all_fonts = false;
         let font_combo_state = build_font_combo_state(
@@ -154,6 +156,7 @@ impl App {
             resize_debounce_pending: false,
             resize_debounce_seq: 0,
             resize_debounce_spawned_seq: 0,
+            palette,
             shell_picker_anim: Animation::new(false)
                 .duration(std::time::Duration::from_millis(250))
                 .easing(iced::animation::Easing::EaseOutQuint),

--- a/src/gui/app/update/settings.rs
+++ b/src/gui/app/update/settings.rs
@@ -35,6 +35,7 @@ impl App {
 
     pub(super) fn apply_updates_to_runtime(&mut self, updates: AppConfigUpdates) -> Task<Message> {
         self.config.apply_updates(updates);
+        self.palette = crate::gui::theme::Palette::from_theme(&self.config.theme);
         self.settings_draft = SettingsDraft::from_config(&self.config);
 
         let new_size = Size::new(self.config.ui.window_width, self.config.ui.window_height);

--- a/src/gui/app/view/dialog.rs
+++ b/src/gui/app/view/dialog.rs
@@ -15,9 +15,8 @@ pub(in crate::gui) fn confirm_dialog<'a>(
     description: &str,
     buttons: Vec<DialogButton>,
     on_dismiss: Message,
+    palette: Palette,
 ) -> Element<'a, Message> {
-    let palette = Palette::DARK;
-
     let backdrop = mouse_area(
         container(text(""))
             .width(Length::Fill)

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -22,6 +22,7 @@ impl App {
     }
 
     fn view_main(&self) -> Element<'_, Message> {
+        let palette = self.palette;
         let tabs_iter = self
             .tabs
             .iter()
@@ -47,6 +48,7 @@ impl App {
             tab_alpha,
             self.dragging_tab,
             self.drag_target,
+            palette,
         );
 
         let main_content: Element<Message> = if self.active_tab == SETTINGS_TAB_INDEX {
@@ -60,7 +62,7 @@ impl App {
             let version_label = text(format!("RabbiTTY v{}", env!("CARGO_PKG_VERSION")))
                 .size(13)
                 .color(iced::Color::from_rgba(1.0, 1.0, 1.0, 0.4));
-            let new_tab_btn = button_primary("New Tab").on_press(Message::OpenShellPicker);
+            let new_tab_btn = button_primary("New Tab", palette).on_press(Message::OpenShellPicker);
             container(
                 column![logo, version_label, new_tab_btn]
                     .spacing(12)
@@ -98,6 +100,7 @@ impl App {
                     },
                 ],
                 Message::CancelRestartForBlur,
+                palette,
             );
         }
 
@@ -152,7 +155,7 @@ impl App {
                     let rel = viewport.relative_offset();
                     Message::TerminalScroll(rel.y)
                 })
-                .style(crate::gui::theme::scrollbar_style)
+                .style(crate::gui::theme::scrollbar_style(self.palette))
                 .width(Length::Fixed(14.0))
                 .height(Length::Fill);
 

--- a/src/gui/app/view/settings.rs
+++ b/src/gui/app/view/settings.rs
@@ -1,13 +1,13 @@
 use super::super::{App, Message};
 use crate::gui::components::{button_primary, button_secondary};
 use crate::gui::settings::{self, SettingsCategory};
-use crate::gui::theme::{Palette, RADIUS_NORMAL, SPACING_LARGE, SPACING_NORMAL, SPACING_SMALL};
+use crate::gui::theme::{RADIUS_NORMAL, SPACING_LARGE, SPACING_NORMAL, SPACING_SMALL};
 use iced::widget::{button, column, container, row, scrollable, text};
 use iced::{Background, Border, Color, Element, Length};
 
 impl App {
     pub(in crate::gui) fn view_settings(&self) -> Element<'_, Message> {
-        let palette = Palette::DARK;
+        let palette = self.palette;
         let mut category_items: Vec<Element<Message>> = Vec::new();
 
         for category in SettingsCategory::ALL {
@@ -89,8 +89,8 @@ impl App {
             breadcrumb,
             container("").width(Length::Fill),
             row![
-                button_secondary("Apply").on_press(Message::ApplySettings),
-                button_primary("Save").on_press(Message::SaveSettings),
+                button_secondary("Apply", palette).on_press(Message::ApplySettings),
+                button_primary("Save", palette).on_press(Message::SaveSettings),
             ]
             .spacing(SPACING_SMALL)
         ]
@@ -105,6 +105,7 @@ impl App {
             &self.font_combo_state,
             self.show_all_fonts,
             &self.all_font_options,
+            palette,
         ))
         .padding([0, 12])
         .width(Length::Fill);

--- a/src/gui/app/view/shell_picker.rs
+++ b/src/gui/app/view/shell_picker.rs
@@ -12,7 +12,7 @@ impl App {
         &'a self,
         base_layout: impl Into<Element<'a, Message>>,
     ) -> Element<'a, Message> {
-        let palette = Palette::DARK;
+        let palette = self.palette;
         let now = Instant::now();
 
         let progress: f32 = self.shell_picker_anim.interpolate(0.0f32, 1.0f32, now);
@@ -48,10 +48,10 @@ impl App {
                 })
                 .into(),
         );
-        items.push(divider_with_alpha(progress));
+        items.push(divider_with_alpha(progress, palette));
 
         // Shell section
-        items.push(section_label("Shells", progress));
+        items.push(section_label("Shells", progress, palette));
 
         for shell in &self.available_shells {
             let label = shell.display_name();
@@ -67,14 +67,15 @@ impl App {
                 selected,
                 Message::CreateTab(shell.clone()),
                 progress,
+                palette,
             ));
             option_index += 1;
         }
 
         // SSH section
         if !self.config.ssh_profiles.is_empty() {
-            items.push(divider_with_alpha(progress));
-            items.push(section_label("SSH", progress));
+            items.push(divider_with_alpha(progress, palette));
+            items.push(section_label("SSH", progress, palette));
 
             for (i, profile) in self.config.ssh_profiles.iter().enumerate() {
                 let label = if profile.name.is_empty() {
@@ -97,6 +98,7 @@ impl App {
                     selected,
                     Message::CreateSshTab(i),
                     progress,
+                    palette,
                 ));
                 option_index += 1;
             }
@@ -146,8 +148,7 @@ impl App {
     }
 }
 
-fn section_label(label: &str, alpha: f32) -> Element<'_, Message> {
-    let palette = Palette::DARK;
+fn section_label(label: &str, alpha: f32, palette: Palette) -> Element<'_, Message> {
     text(label)
         .size(11)
         .color(Color {
@@ -157,8 +158,7 @@ fn section_label(label: &str, alpha: f32) -> Element<'_, Message> {
         .into()
 }
 
-fn divider_with_alpha(alpha: f32) -> Element<'static, Message> {
-    let palette = Palette::DARK;
+fn divider_with_alpha(alpha: f32, palette: Palette) -> Element<'static, Message> {
     container(text(""))
         .width(Length::Fill)
         .height(1)
@@ -178,9 +178,8 @@ fn picker_item(
     selected: bool,
     on_press: Message,
     alpha: f32,
+    palette: Palette,
 ) -> Element<'static, Message> {
-    let palette = Palette::DARK;
-
     let mut content_items: Vec<Element<'static, Message>> = vec![
         text(label)
             .size(13)

--- a/src/gui/components/button.rs
+++ b/src/gui/components/button.rs
@@ -4,11 +4,10 @@ use iced::{Background, Border, Color, Shadow, Theme};
 
 const RADIUS: f32 = 6.0;
 
-pub fn primary(text: &str) -> button::Button<'_, crate::gui::app::Message> {
+pub fn primary(text: &str, palette: Palette) -> button::Button<'_, crate::gui::app::Message> {
     button(iced::widget::text(text).size(13))
         .padding([7, 16])
-        .style(|_theme: &Theme, status: button::Status| {
-            let palette = Palette::DARK;
+        .style(move |_theme: &Theme, status: button::Status| {
             let bg = match status {
                 button::Status::Hovered => Color {
                     r: palette.accent.r * 1.1,
@@ -41,11 +40,10 @@ pub fn primary(text: &str) -> button::Button<'_, crate::gui::app::Message> {
         })
 }
 
-pub fn secondary(text: &str) -> button::Button<'_, crate::gui::app::Message> {
+pub fn secondary(text: &str, palette: Palette) -> button::Button<'_, crate::gui::app::Message> {
     button(iced::widget::text(text).size(13))
         .padding([7, 16])
-        .style(|_theme: &Theme, status: button::Status| {
-            let palette = Palette::DARK;
+        .style(move |_theme: &Theme, status: button::Status| {
             let (bg, border_alpha) = match status {
                 button::Status::Hovered => (
                     Color {

--- a/src/gui/components/mod.rs
+++ b/src/gui/components/mod.rs
@@ -2,8 +2,21 @@ pub mod button;
 pub mod container;
 pub mod tab_bar;
 
-// Re-export components for easier access
-pub use button::primary as button_primary;
-pub use button::secondary as button_secondary;
+use crate::gui::theme::Palette;
+
+pub fn button_primary(
+    text: &str,
+    palette: Palette,
+) -> iced::widget::button::Button<'_, crate::gui::app::Message> {
+    button::primary(text, palette)
+}
+
+pub fn button_secondary(
+    text: &str,
+    palette: Palette,
+) -> iced::widget::button::Button<'_, crate::gui::app::Message> {
+    button::secondary(text, palette)
+}
+
 pub use container::panel;
 pub use tab_bar::tab_bar;

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -193,7 +193,12 @@ fn browser_tab<'a>(
     } else {
         title.into()
     };
-    let index_label = text(format!("{}", index + 1)).size(10).color(Color {
+    let index_label = if index == crate::gui::app::SETTINGS_TAB_INDEX {
+        text("\u{2699}".to_string()).size(10)
+    } else {
+        text(format!("{}", index + 1)).size(10)
+    }
+    .color(Color {
         a: 0.35,
         ..palette.text_secondary
     });

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -4,6 +4,7 @@ use iced::widget::mouse_area;
 use iced::widget::{button, container, row, scrollable, text};
 use iced::{Background, Border, Color, Element, Length, Theme};
 
+#[allow(clippy::too_many_arguments)]
 pub fn tab_bar<'a>(
     tabs: impl Iterator<Item = (&'a str, usize, bool)>,
     on_add: Message,
@@ -12,9 +13,8 @@ pub fn tab_bar<'a>(
     tab_alpha: f32,
     dragging_tab: Option<usize>,
     drag_target: Option<usize>,
+    palette: Palette,
 ) -> Element<'a, Message> {
-    let palette = Palette::DARK;
-
     let mut tab_elements: Vec<Element<Message>> = Vec::new();
     let is_reordering =
         dragging_tab.is_some() && drag_target.is_some() && dragging_tab != drag_target;
@@ -40,7 +40,7 @@ pub fn tab_bar<'a>(
             tab_elements.push(gap.into());
         }
 
-        let tab_item = browser_tab(title, index, is_active, tab_alpha);
+        let tab_item = browser_tab(title, index, is_active, tab_alpha, palette);
         let tab_item = mouse_area(tab_item)
             .on_press(Message::TabSelected(index))
             .on_enter(Message::TabDragHover(index))
@@ -73,7 +73,7 @@ pub fn tab_bar<'a>(
         .on_press(on_add)
         .padding([6, 10])
         .style(icon_style);
-    let settings_btn = button(text("⚙").size(13))
+    let settings_btn = button(text("\u{2699}").size(13))
         .on_press(on_settings)
         .padding([6, 10])
         .style(icon_style);
@@ -89,7 +89,7 @@ pub fn tab_bar<'a>(
         .on_scroll(|viewport: scrollable::Viewport| {
             Message::TabBarScrolled(viewport.absolute_offset().x)
         })
-        .style(crate::gui::theme::scrollbar_style)
+        .style(crate::gui::theme::scrollbar_style(palette))
         .width(Length::Fill)
         .height(Length::Shrink);
 
@@ -127,15 +127,15 @@ pub fn tab_bar<'a>(
         };
 
         row![
-            button(text("─").size(12))
+            button(text("\u{2500}").size(12))
                 .on_press(Message::WindowMinimize)
                 .padding([6, 12])
                 .style(win_style(hover_subtle)),
-            button(text("□").size(12))
+            button(text("\u{25a1}").size(12))
                 .on_press(Message::WindowMaximize)
                 .padding([6, 12])
                 .style(win_style(hover_subtle)),
-            button(text("✕").size(12))
+            button(text("\u{2715}").size(12))
                 .on_press(Message::Exit)
                 .padding([6, 12])
                 .style(win_style(hover_close)),
@@ -184,13 +184,12 @@ fn browser_tab<'a>(
     index: usize,
     is_active: bool,
     tab_alpha: f32,
+    palette: Palette,
 ) -> Element<'a, Message> {
-    let palette = Palette::DARK;
-
     const MAX_TITLE_LEN: usize = 24;
     let display_title: std::borrow::Cow<'a, str> = if title.chars().count() > MAX_TITLE_LEN {
         let truncated: String = title.chars().take(MAX_TITLE_LEN - 1).collect();
-        format!("{truncated}…").into()
+        format!("{truncated}\u{2026}").into()
     } else {
         title.into()
     };
@@ -200,7 +199,7 @@ fn browser_tab<'a>(
     });
     let tab_text = text(display_title).size(12);
 
-    let close_btn = button(text("✕").size(9))
+    let close_btn = button(text("\u{2715}").size(9))
         .on_press(Message::CloseTab(index))
         .padding([2, 5])
         .style(

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -327,7 +327,7 @@ pub fn view_category<'a>(
     palette: Palette,
 ) -> Element<'a, Message> {
     match category {
-        SettingsCategory::Ui => ui::view(config, draft),
+        SettingsCategory::Ui => ui::view(config, draft, palette),
         SettingsCategory::Terminal => {
             let selected_font = all_font_options
                 .iter()
@@ -338,22 +338,28 @@ pub fn view_category<'a>(
                 font_combo_state,
                 show_all_fonts,
                 selected_font,
+                palette,
             )
         }
         SettingsCategory::Theme => theme::view(config, draft, palette),
-        SettingsCategory::Shortcuts => shortcuts::view(config, draft),
+        SettingsCategory::Shortcuts => shortcuts::view(config, draft, palette),
         SettingsCategory::Ssh => ssh::view(draft, palette),
     }
 }
 
 const LABEL_WIDTH: f32 = 160.0;
 
-pub fn input_row<'a>(label: &'a str, value: &'a str, field: SettingsField) -> Element<'a, Message> {
+pub fn input_row<'a>(
+    label: &'a str,
+    value: &'a str,
+    field: SettingsField,
+    palette: Palette,
+) -> Element<'a, Message> {
     row![
         text(label).size(13).width(Length::Fixed(LABEL_WIDTH)),
         styled_text_input(value, move |next| Message::SettingsInputChanged(
             field, next
-        )),
+        ), palette),
     ]
     .align_y(Alignment::Center)
     .spacing(SPACING_NORMAL)
@@ -366,13 +372,13 @@ pub fn input_row_with_suffix<'a>(
     value: &'a str,
     field: SettingsField,
     suffix: &'a str,
+    palette: Palette,
 ) -> Element<'a, Message> {
-    let palette = Palette::DARK;
     row![
         text(label).size(13).width(Length::Fixed(LABEL_WIDTH)),
         styled_text_input(value, move |next| Message::SettingsInputChanged(
             field, next
-        )),
+        ), palette),
         text(suffix)
             .size(12)
             .color(palette.text_secondary)
@@ -389,8 +395,8 @@ pub fn color_input_row<'a>(
     label: &'a str,
     value: &'a str,
     field: SettingsField,
+    palette: Palette,
 ) -> Element<'a, Message> {
-    let palette = Palette::DARK;
     let parsed = parse_hex_color(value);
     let dot_color = parsed
         .map(|rgb| Color::from_rgb8(rgb[0], rgb[1], rgb[2]))
@@ -415,7 +421,7 @@ pub fn color_input_row<'a>(
             }),
         styled_text_input(value, move |next| Message::SettingsInputChanged(
             field, next
-        )),
+        ), palette),
     ]
     .align_y(Alignment::Center)
     .spacing(SPACING_NORMAL)
@@ -436,14 +442,12 @@ pub fn toggle_row<'a>(label: &'a str, value: bool) -> Element<'a, Message> {
     .into()
 }
 
-pub fn hint_text<'a>(msg: &'a str) -> Element<'a, Message> {
-    let palette = Palette::DARK;
+pub fn hint_text<'a>(msg: &'a str, palette: Palette) -> Element<'a, Message> {
     text(msg).size(11).color(palette.text_secondary).into()
 }
 
 #[allow(dead_code)]
-pub fn divider<'a>() -> Element<'a, Message> {
-    let palette = Palette::DARK;
+pub fn divider<'a>(palette: Palette) -> Element<'a, Message> {
     container(
         rule::horizontal(1).style(move |_theme: &iced::Theme| rule::Style {
             color: Color {
@@ -460,8 +464,7 @@ pub fn divider<'a>() -> Element<'a, Message> {
     .into()
 }
 
-pub fn section<'a>(title: &'a str, body: Element<'a, Message>) -> Element<'a, Message> {
-    let palette = Palette::DARK;
+pub fn section<'a>(title: &'a str, body: Element<'a, Message>, palette: Palette) -> Element<'a, Message> {
     container(
         column(vec![
             text(title).size(14).color(palette.accent).into(),
@@ -501,11 +504,14 @@ pub fn section<'a>(title: &'a str, body: Element<'a, Message>) -> Element<'a, Me
     .into()
 }
 
-fn styled_text_input<'a, F>(value: &'a str, on_input: F) -> text_input::TextInput<'a, Message>
+fn styled_text_input<'a, F>(
+    value: &'a str,
+    on_input: F,
+    palette: Palette,
+) -> text_input::TextInput<'a, Message>
 where
     F: 'a + Fn(String) -> Message,
 {
-    let palette = Palette::DARK;
     text_input("", value)
         .on_input(on_input)
         .padding([6, 10])
@@ -546,11 +552,11 @@ where
 pub fn styled_text_input_small<'a, F>(
     value: &'a str,
     on_input: F,
+    palette: Palette,
 ) -> text_input::TextInput<'a, Message>
 where
     F: 'a + Fn(String) -> Message,
 {
-    let palette = Palette::DARK;
     text_input("", value)
         .on_input(on_input)
         .padding([4, 8])

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -357,9 +357,11 @@ pub fn input_row<'a>(
 ) -> Element<'a, Message> {
     row![
         text(label).size(13).width(Length::Fixed(LABEL_WIDTH)),
-        styled_text_input(value, move |next| Message::SettingsInputChanged(
-            field, next
-        ), palette),
+        styled_text_input(
+            value,
+            move |next| Message::SettingsInputChanged(field, next),
+            palette
+        ),
     ]
     .align_y(Alignment::Center)
     .spacing(SPACING_NORMAL)
@@ -376,9 +378,11 @@ pub fn input_row_with_suffix<'a>(
 ) -> Element<'a, Message> {
     row![
         text(label).size(13).width(Length::Fixed(LABEL_WIDTH)),
-        styled_text_input(value, move |next| Message::SettingsInputChanged(
-            field, next
-        ), palette),
+        styled_text_input(
+            value,
+            move |next| Message::SettingsInputChanged(field, next),
+            palette
+        ),
         text(suffix)
             .size(12)
             .color(palette.text_secondary)
@@ -419,9 +423,11 @@ pub fn color_input_row<'a>(
                 },
                 ..Default::default()
             }),
-        styled_text_input(value, move |next| Message::SettingsInputChanged(
-            field, next
-        ), palette),
+        styled_text_input(
+            value,
+            move |next| Message::SettingsInputChanged(field, next),
+            palette
+        ),
     ]
     .align_y(Alignment::Center)
     .spacing(SPACING_NORMAL)
@@ -464,7 +470,11 @@ pub fn divider<'a>(palette: Palette) -> Element<'a, Message> {
     .into()
 }
 
-pub fn section<'a>(title: &'a str, body: Element<'a, Message>, palette: Palette) -> Element<'a, Message> {
+pub fn section<'a>(
+    title: &'a str,
+    body: Element<'a, Message>,
+    palette: Palette,
+) -> Element<'a, Message> {
     container(
         column(vec![
             text(title).size(14).color(palette.accent).into(),

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -324,6 +324,7 @@ pub fn view_category<'a>(
     font_combo_state: &'a iced::widget::combo_box::State<TerminalFontOption>,
     show_all_fonts: bool,
     all_font_options: &'a [TerminalFontOption],
+    palette: Palette,
 ) -> Element<'a, Message> {
     match category {
         SettingsCategory::Ui => ui::view(config, draft),
@@ -339,9 +340,9 @@ pub fn view_category<'a>(
                 selected_font,
             )
         }
-        SettingsCategory::Theme => theme::view(config, draft),
+        SettingsCategory::Theme => theme::view(config, draft, palette),
         SettingsCategory::Shortcuts => shortcuts::view(config, draft),
-        SettingsCategory::Ssh => ssh::view(draft),
+        SettingsCategory::Ssh => ssh::view(draft, palette),
     }
 }
 

--- a/src/gui/settings/shortcuts.rs
+++ b/src/gui/settings/shortcuts.rs
@@ -5,7 +5,11 @@ use crate::gui::theme::{Palette, SPACING_NORMAL};
 use iced::widget::column;
 use iced::{Element, Length};
 
-pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft, palette: Palette) -> Element<'a, Message> {
+pub fn view<'a>(
+    _config: &'a AppConfig,
+    draft: &'a SettingsDraft,
+    palette: Palette,
+) -> Element<'a, Message> {
     let app_section = section(
         "Application",
         column(vec![
@@ -39,8 +43,16 @@ pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft, palette: Palet
                 SettingsField::ShortcutPrevTab,
                 palette,
             ),
-            input_row("Quit", &draft.shortcut_quit, SettingsField::ShortcutQuit, palette),
-            hint_text("Format: Command+T, Ctrl+W, Ctrl+PageDown, Command+Comma", palette),
+            input_row(
+                "Quit",
+                &draft.shortcut_quit,
+                SettingsField::ShortcutQuit,
+                palette,
+            ),
+            hint_text(
+                "Format: Command+T, Ctrl+W, Ctrl+PageDown, Command+Comma",
+                palette,
+            ),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)

--- a/src/gui/settings/shortcuts.rs
+++ b/src/gui/settings/shortcuts.rs
@@ -1,11 +1,11 @@
 use crate::config::AppConfig;
 use crate::gui::app::Message;
 use crate::gui::settings::{SettingsDraft, SettingsField, hint_text, input_row, section};
-use crate::gui::theme::SPACING_NORMAL;
+use crate::gui::theme::{Palette, SPACING_NORMAL};
 use iced::widget::column;
 use iced::{Element, Length};
 
-pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft) -> Element<'a, Message> {
+pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft, palette: Palette) -> Element<'a, Message> {
     let app_section = section(
         "Application",
         column(vec![
@@ -13,33 +13,39 @@ pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft) -> Element<'a,
                 "New tab",
                 &draft.shortcut_new_tab,
                 SettingsField::ShortcutNewTab,
+                palette,
             ),
             input_row(
                 "Close tab",
                 &draft.shortcut_close_tab,
                 SettingsField::ShortcutCloseTab,
+                palette,
             ),
             input_row(
                 "Open settings",
                 &draft.shortcut_open_settings,
                 SettingsField::ShortcutOpenSettings,
+                palette,
             ),
             input_row(
                 "Next tab",
                 &draft.shortcut_next_tab,
                 SettingsField::ShortcutNextTab,
+                palette,
             ),
             input_row(
                 "Previous tab",
                 &draft.shortcut_prev_tab,
                 SettingsField::ShortcutPrevTab,
+                palette,
             ),
-            input_row("Quit", &draft.shortcut_quit, SettingsField::ShortcutQuit),
-            hint_text("Format: Command+T, Ctrl+W, Ctrl+PageDown, Command+Comma"),
+            input_row("Quit", &draft.shortcut_quit, SettingsField::ShortcutQuit, palette),
+            hint_text("Format: Command+T, Ctrl+W, Ctrl+PageDown, Command+Comma", palette),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),
+        palette,
     );
 
     column(vec![app_section])

--- a/src/gui/settings/ssh.rs
+++ b/src/gui/settings/ssh.rs
@@ -1,26 +1,25 @@
 use crate::gui::app::Message;
+use crate::gui::components::{button_primary, button_secondary};
 use crate::gui::settings::{SettingsDraft, SshProfileDraft, SshProfileField};
 use crate::gui::theme::{Palette, RADIUS_SMALL, SPACING_NORMAL, SPACING_SMALL};
 use iced::widget::{column, container, row, text, text_input};
 use iced::{Alignment, Background, Border, Color, Element, Length};
 
-use crate::gui::components::{button_primary, button_secondary};
-
-pub fn view(draft: &SettingsDraft) -> Element<'_, Message> {
+pub fn view(draft: &SettingsDraft, palette: Palette) -> Element<'_, Message> {
     let mut items: Vec<Element<Message>> = Vec::new();
 
     for (i, profile) in draft.ssh_profiles.iter().enumerate() {
-        items.push(profile_card(i, profile));
+        items.push(profile_card(i, profile, palette));
     }
 
     if draft.ssh_profiles.is_empty() {
-        items.push(empty_state());
+        items.push(empty_state(palette));
     }
 
     items.push(
         row![
-            button_primary("+ Add Profile").on_press(Message::AddSshProfile),
-            button_primary("Save All").on_press(Message::SaveSshProfiles),
+            button_primary("+ Add Profile", palette).on_press(Message::AddSshProfile),
+            button_primary("Save All", palette).on_press(Message::SaveSshProfiles),
         ]
         .spacing(SPACING_SMALL)
         .into(),
@@ -32,11 +31,10 @@ pub fn view(draft: &SettingsDraft) -> Element<'_, Message> {
         .into()
 }
 
-fn empty_state<'a>() -> Element<'a, Message> {
-    let palette = Palette::DARK;
+fn empty_state(palette: Palette) -> Element<'static, Message> {
     container(
         column![
-            text("⇄").size(28).color(Color {
+            text("\u{21c4}").size(28).color(Color {
                 a: 0.3,
                 ..palette.text
             }),
@@ -56,9 +54,11 @@ fn empty_state<'a>() -> Element<'a, Message> {
     .into()
 }
 
-fn profile_card<'a>(index: usize, profile: &'a SshProfileDraft) -> Element<'a, Message> {
-    let palette = Palette::DARK;
-
+fn profile_card<'a>(
+    index: usize,
+    profile: &'a SshProfileDraft,
+    palette: Palette,
+) -> Element<'a, Message> {
     // Dynamic title: show preview of connection
     let title = if !profile.name.is_empty() {
         profile.name.clone()
@@ -73,7 +73,7 @@ fn profile_card<'a>(index: usize, profile: &'a SshProfileDraft) -> Element<'a, M
     let title_row = row![
         text(title).size(14).color(palette.accent),
         container("").width(Length::Fill),
-        button_secondary("Remove").on_press(Message::RemoveSshProfile(index)),
+        button_secondary("Remove", palette).on_press(Message::RemoveSshProfile(index)),
     ]
     .align_y(Alignment::Center)
     .width(Length::Fill);
@@ -91,22 +91,37 @@ fn profile_card<'a>(index: usize, profile: &'a SshProfileDraft) -> Element<'a, M
 
     // Connection section: host:port on one row, user below
     let host_port_row = row![
-        styled_input("Host", &profile.host, index, SshProfileField::Host).width(Length::Fill),
+        styled_input("Host", &profile.host, index, SshProfileField::Host, palette)
+            .width(Length::Fill),
         text(":").size(13).color(palette.text_secondary),
-        styled_input_small("Port", &profile.port, index, SshProfileField::Port, 60.0),
+        styled_input_small(
+            "Port",
+            &profile.port,
+            index,
+            SshProfileField::Port,
+            60.0,
+            palette
+        ),
     ]
     .spacing(4)
     .align_y(Alignment::Center)
     .width(Length::Fill);
 
-    let user_row =
-        styled_input("Username", &profile.user, index, SshProfileField::User).width(Length::Fill);
+    let user_row = styled_input(
+        "Username",
+        &profile.user,
+        index,
+        SshProfileField::User,
+        palette,
+    )
+    .width(Length::Fill);
 
     let name_row = styled_input(
         "Display Name (optional)",
         &profile.name,
         index,
         SshProfileField::Name,
+        palette,
     )
     .width(Length::Fill);
 
@@ -120,10 +135,11 @@ fn profile_card<'a>(index: usize, profile: &'a SshProfileDraft) -> Element<'a, M
         &profile.identity_file,
         index,
         SshProfileField::IdentityFile,
+        palette,
     )
     .width(Length::Fill);
 
-    let password_row = styled_password("Password", &profile.password, index);
+    let password_row = styled_password("Password", &profile.password, index, palette);
 
     let auth_hint = text("Password is stored securely in your OS keychain")
         .size(10)
@@ -172,8 +188,8 @@ fn styled_input<'a>(
     value: &'a str,
     index: usize,
     field: SshProfileField,
+    palette: Palette,
 ) -> text_input::TextInput<'a, Message> {
-    let palette = Palette::DARK;
     text_input(placeholder, value)
         .on_input(move |next| Message::SshProfileFieldChanged(index, field, next))
         .padding([6, 10])
@@ -187,8 +203,8 @@ fn styled_input_small<'a>(
     index: usize,
     field: SshProfileField,
     width: f32,
+    palette: Palette,
 ) -> text_input::TextInput<'a, Message> {
-    let palette = Palette::DARK;
     text_input(placeholder, value)
         .on_input(move |next| Message::SshProfileFieldChanged(index, field, next))
         .padding([6, 10])
@@ -201,8 +217,8 @@ fn styled_password<'a>(
     placeholder: &'a str,
     value: &'a str,
     index: usize,
+    palette: Palette,
 ) -> text_input::TextInput<'a, Message> {
-    let palette = Palette::DARK;
     text_input(placeholder, value)
         .secure(true)
         .on_input(move |next| {

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -3,7 +3,7 @@ use crate::gui::app::Message;
 use crate::gui::settings::{
     SettingsDraft, SettingsField, TerminalFontOption, hint_text, input_row_with_suffix, section,
 };
-use crate::gui::theme::SPACING_NORMAL;
+use crate::gui::theme::{Palette, SPACING_NORMAL};
 use iced::widget::{checkbox, column, combo_box, row, text};
 use iced::{Alignment, Element, Length};
 
@@ -13,6 +13,7 @@ pub fn view<'a>(
     font_combo_state: &'a combo_box::State<TerminalFontOption>,
     show_all_fonts: bool,
     selected_font: Option<&'a TerminalFontOption>,
+    palette: Palette,
 ) -> Element<'a, Message> {
     let font_section = section(
         "Font",
@@ -22,6 +23,7 @@ pub fn view<'a>(
                 &draft.terminal_font_size,
                 SettingsField::TerminalFontSize,
                 "pt",
+                palette,
             ),
             row![
                 text("Font family").size(13).width(Length::Fixed(160.0)),
@@ -49,11 +51,12 @@ pub fn view<'a>(
                 "Using bundled DejaVu Sans Mono."
             } else {
                 "Monospaced fonts are recommended for terminal text."
-            }),
+            }, palette),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),
+        palette,
     );
 
     let padding_section = section(
@@ -64,17 +67,20 @@ pub fn view<'a>(
                 &draft.terminal_padding_x,
                 SettingsField::TerminalPaddingX,
                 "px",
+                palette,
             ),
             input_row_with_suffix(
                 "Vertical",
                 &draft.terminal_padding_y,
                 SettingsField::TerminalPaddingY,
                 "px",
+                palette,
             ),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),
+        palette,
     );
 
     column(vec![font_section, padding_section])

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -47,11 +47,14 @@ pub fn view<'a>(
                     .text_size(13),
             ]
             .into(),
-            hint_text(if draft.terminal_font_selection.is_empty() {
-                "Using bundled DejaVu Sans Mono."
-            } else {
-                "Monospaced fonts are recommended for terminal text."
-            }, palette),
+            hint_text(
+                if draft.terminal_font_selection.is_empty() {
+                    "Using bundled DejaVu Sans Mono."
+                } else {
+                    "Monospaced fonts are recommended for terminal text."
+                },
+                palette,
+            ),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)

--- a/src/gui/settings/theme.rs
+++ b/src/gui/settings/theme.rs
@@ -24,6 +24,7 @@ pub fn view<'a>(
             .spacing(SPACING_NORMAL)
             .width(Length::Fill)
             .into(),
+        palette,
     );
 
     // -- Color palette pickers for fg/bg/cursor --
@@ -52,11 +53,12 @@ pub fn view<'a>(
                 current_preset,
                 &palette,
             ),
-            hint_text("Click a swatch or type hex (#rrggbb)"),
+            hint_text("Click a swatch or type hex (#rrggbb)", palette),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),
+        palette,
     );
 
     let opacity_section = section(
@@ -66,21 +68,24 @@ pub fn view<'a>(
             &draft.background_opacity,
             SettingsField::ThemeBackgroundOpacity,
             "0.0 ~ 1.0",
+            palette,
         )])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),
+        palette,
     );
 
     let blur_section = section(
         "Blur",
         column(vec![
             toggle_row("Enable blur", draft.blur_enabled),
-            hint_text("On macOS, changing this requires restart."),
+            hint_text("On macOS, changing this requires restart.", palette),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),
+        palette,
     );
 
     #[cfg(target_os = "macos")]
@@ -92,12 +97,14 @@ pub fn view<'a>(
                 &draft.macos_blur_radius,
                 SettingsField::ThemeMacosBlurRadius,
                 "0 ~ 100",
+                palette,
             ),
-            hint_text("Controls the intensity of the window background blur effect."),
+            hint_text("Controls the intensity of the window background blur effect.", palette),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),
+        palette,
     );
 
     #[cfg(target_os = "macos")]
@@ -290,7 +297,7 @@ fn color_palette_row<'a>(
     // Current color indicator + hex input
     let hex_input = crate::gui::settings::styled_text_input_small(current_hex, move |next| {
         Message::SettingsInputChanged(field, next)
-    });
+    }, *palette);
 
     column![
         row![

--- a/src/gui/settings/theme.rs
+++ b/src/gui/settings/theme.rs
@@ -4,7 +4,7 @@ use crate::gui::settings::{
     SettingsDraft, SettingsField, format_rgb, hint_text, input_row_with_suffix, section, toggle_row,
 };
 use crate::gui::theme::{Palette, RADIUS_SMALL, SPACING_NORMAL};
-use crate::terminal::theme::{ColorPreset, PRESETS};
+use crate::terminal::theme::{ColorPreset, all_presets};
 use iced::widget::{Column, Row, button, column, container, row, text};
 use iced::{Background, Border, Color, Element, Length};
 
@@ -135,7 +135,7 @@ pub fn view<'a>(
 
 /// Build preset cards in a 2-column grid.
 fn build_preset_grid<'a>(draft: &'a SettingsDraft, palette: &Palette) -> Vec<Element<'a, Message>> {
-    let cards: Vec<Element<'a, Message>> = PRESETS
+    let cards: Vec<Element<'a, Message>> = all_presets()
         .iter()
         .map(|preset| build_preset_card(preset, draft, palette))
         .collect();
@@ -171,7 +171,7 @@ fn build_preset_card<'a>(
     draft: &'a SettingsDraft,
     palette: &Palette,
 ) -> Element<'a, Message> {
-    let is_selected = draft.color_scheme.eq_ignore_ascii_case(preset.name);
+    let is_selected = draft.color_scheme.eq_ignore_ascii_case(&preset.name);
 
     // Color swatches: bg, fg, then 6 ANSI colors
     let swatches: Vec<Element<'a, Message>> = std::iter::once(preset.bg)
@@ -197,8 +197,8 @@ fn build_preset_card<'a>(
     };
     let border_width = if is_selected { 2.0 } else { 1.0 };
 
-    let name = preset.name;
-    let card_content = column![text(name).size(12).color(card_fg), swatch_row]
+    let name = &preset.name;
+    let card_content = column![text(name.as_str()).size(12).color(card_fg), swatch_row]
         .spacing(6)
         .width(Length::Fill);
 

--- a/src/gui/settings/theme.rs
+++ b/src/gui/settings/theme.rs
@@ -99,7 +99,10 @@ pub fn view<'a>(
                 "0 ~ 100",
                 palette,
             ),
-            hint_text("Controls the intensity of the window background blur effect.", palette),
+            hint_text(
+                "Controls the intensity of the window background blur effect.",
+                palette,
+            ),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
@@ -295,9 +298,11 @@ fn color_palette_row<'a>(
     let swatch_grid = Row::with_children(swatches).spacing(4).width(Length::Fill);
 
     // Current color indicator + hex input
-    let hex_input = crate::gui::settings::styled_text_input_small(current_hex, move |next| {
-        Message::SettingsInputChanged(field, next)
-    }, *palette);
+    let hex_input = crate::gui::settings::styled_text_input_small(
+        current_hex,
+        move |next| Message::SettingsInputChanged(field, next),
+        *palette,
+    );
 
     column![
         row![

--- a/src/gui/settings/theme.rs
+++ b/src/gui/settings/theme.rs
@@ -10,9 +10,11 @@ use iced::{Background, Border, Color, Element, Length};
 
 const LABEL_WIDTH: f32 = 160.0;
 
-pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft) -> Element<'a, Message> {
-    let palette = Palette::DARK;
-
+pub fn view<'a>(
+    _config: &'a AppConfig,
+    draft: &'a SettingsDraft,
+    palette: Palette,
+) -> Element<'a, Message> {
     // -- Preset picker: 2-column grid of visual cards --
     let grid_rows = build_preset_grid(draft, &palette);
 

--- a/src/gui/settings/ui.rs
+++ b/src/gui/settings/ui.rs
@@ -1,11 +1,11 @@
 use crate::config::AppConfig;
 use crate::gui::app::Message;
 use crate::gui::settings::{SettingsDraft, SettingsField, input_row_with_suffix, section};
-use crate::gui::theme::SPACING_NORMAL;
+use crate::gui::theme::{Palette, SPACING_NORMAL};
 use iced::widget::column;
 use iced::{Element, Length};
 
-pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft) -> Element<'a, Message> {
+pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft, palette: Palette) -> Element<'a, Message> {
     let window_section = section(
         "Window",
         column(vec![
@@ -14,17 +14,20 @@ pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft) -> Element<'a,
                 &draft.window_width,
                 SettingsField::UiWindowWidth,
                 "px",
+                palette,
             ),
             input_row_with_suffix(
                 "Height",
                 &draft.window_height,
                 SettingsField::UiWindowHeight,
                 "px",
+                palette,
             ),
         ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),
+        palette,
     );
 
     column(vec![window_section])

--- a/src/gui/settings/ui.rs
+++ b/src/gui/settings/ui.rs
@@ -5,7 +5,11 @@ use crate::gui::theme::{Palette, SPACING_NORMAL};
 use iced::widget::column;
 use iced::{Element, Length};
 
-pub fn view<'a>(_config: &'a AppConfig, draft: &'a SettingsDraft, palette: Palette) -> Element<'a, Message> {
+pub fn view<'a>(
+    _config: &'a AppConfig,
+    draft: &'a SettingsDraft,
+    palette: Palette,
+) -> Element<'a, Message> {
     let window_section = section(
         "Window",
         column(vec![

--- a/src/gui/terminal.wgsl
+++ b/src/gui/terminal.wgsl
@@ -86,27 +86,14 @@ fn text_vs_main(input : TextVertexIn) -> TextVertexOut {
     return out;
 }
 
-// Convert linear RGB to approximate sRGB (sqrt approximation of gamma 2.2)
-fn linear_to_srgb(c : vec3<f32>) -> vec3<f32> {
-    return sqrt(max(c, vec3<f32>(0.0)));
-}
-
-// Convert approximate sRGB back to linear
-fn srgb_to_linear(c : vec3<f32>) -> vec3<f32> {
-    return c * c;
-}
-
-// Single-pass subpixel: blend fg/bg in sRGB space for perceptually correct text
+// Grayscale anti-aliased text rendering.
+// Subpixel coverage is averaged into a single alpha value, avoiding
+// color fringing on transparent/composited backgrounds and non-RGB-stripe panels.
 @fragment
 fn text_fs_subpixel(input : TextVertexOut) -> @location(0) vec4<f32> {
     let cov = textureSample(text_atlas, text_sampler, input.uv);
-    // Blend in sRGB (gamma) space so text edges look bold and vivid
-    let bg_srgb = linear_to_srgb(input.bg_color.rgb);
-    let fg_srgb = linear_to_srgb(input.color.rgb);
-    let blended_srgb = bg_srgb * (1.0 - cov.rgb) + fg_srgb * cov.rgb;
-    let blended = srgb_to_linear(blended_srgb);
-    let alpha = max(cov.r, max(cov.g, cov.b));
-    return vec4<f32>(blended, mix(input.bg_color.a, input.color.a, alpha));
+    let gray = (cov.r + cov.g + cov.b) / 3.0;
+    return vec4<f32>(input.color.rgb, gray * input.color.a);
 }
 
 struct CompositeVertexIn {

--- a/src/gui/theme.rs
+++ b/src/gui/theme.rs
@@ -24,6 +24,36 @@ impl Palette {
         success: color!(0xa6, 0xe3, 0xa1),    // Green
         error: color!(0xf3, 0x8b, 0xa8),      // Red
     };
+
+    pub fn from_theme(theme: &crate::config::ThemeConfig) -> Self {
+        let bg = theme.background;
+        let fg = theme.foreground;
+
+        let surface = [
+            bg[0].saturating_add(19),
+            bg[1].saturating_add(20),
+            bg[2].saturating_add(22),
+        ];
+        let text_sec = [
+            blend_u8(fg[0], bg[0], 0.35),
+            blend_u8(fg[1], bg[1], 0.35),
+            blend_u8(fg[2], bg[2], 0.35),
+        ];
+
+        Self {
+            background: Color::from_rgb8(bg[0], bg[1], bg[2]),
+            surface: Color::from_rgb8(surface[0], surface[1], surface[2]),
+            text: Color::from_rgb8(fg[0], fg[1], fg[2]),
+            text_secondary: Color::from_rgb8(text_sec[0], text_sec[1], text_sec[2]),
+            accent: color!(0x4d, 0x9e, 0xf7),
+            success: color!(0xa6, 0xe3, 0xa1),
+            error: color!(0xf3, 0x8b, 0xa8),
+        }
+    }
+}
+
+fn blend_u8(from: u8, to: u8, t: f32) -> u8 {
+    (from as f32 + (to as f32 - from as f32) * t) as u8
 }
 
 pub const SPACING_SMALL: f32 = 4.0;
@@ -33,46 +63,49 @@ pub const SPACING_LARGE: f32 = 16.0;
 pub const RADIUS_SMALL: f32 = 4.0;
 pub const RADIUS_NORMAL: f32 = 8.0;
 
-pub fn scrollbar_style(_theme: &iced::Theme, status: scrollable::Status) -> scrollable::Style {
-    let palette = Palette::DARK;
-    let scroller_alpha = match status {
-        scrollable::Status::Active { .. } => 0.45,
-        scrollable::Status::Hovered { .. } => 0.65,
-        scrollable::Status::Dragged { .. } => 0.8,
-    };
+pub fn scrollbar_style(
+    palette: Palette,
+) -> impl Fn(&iced::Theme, scrollable::Status) -> scrollable::Style {
+    move |_theme: &iced::Theme, status: scrollable::Status| {
+        let scroller_alpha = match status {
+            scrollable::Status::Active { .. } => 0.45,
+            scrollable::Status::Hovered { .. } => 0.65,
+            scrollable::Status::Dragged { .. } => 0.8,
+        };
 
-    let rail = |visible: bool| scrollable::Rail {
-        background: Some(Background::Color(if visible {
-            Color {
-                a: 0.08,
-                ..palette.surface
-            }
-        } else {
-            Color::TRANSPARENT
-        })),
-        border: Border::default(),
-        scroller: scrollable::Scroller {
-            background: Background::Color(Color {
-                a: if visible { scroller_alpha } else { 0.0 },
-                ..palette.text_secondary
-            }),
-            border: Border {
-                radius: RADIUS_SMALL.into(),
-                ..Default::default()
-            },
-        },
-    };
-
-    scrollable::Style {
-        container: container::Style::default(),
-        vertical_rail: rail(true),
-        horizontal_rail: rail(true),
-        gap: None,
-        auto_scroll: scrollable::AutoScroll {
-            background: Background::Color(Color::TRANSPARENT),
+        let rail = |visible: bool| scrollable::Rail {
+            background: Some(Background::Color(if visible {
+                Color {
+                    a: 0.08,
+                    ..palette.surface
+                }
+            } else {
+                Color::TRANSPARENT
+            })),
             border: Border::default(),
-            shadow: Shadow::default(),
-            icon: Color::TRANSPARENT,
-        },
+            scroller: scrollable::Scroller {
+                background: Background::Color(Color {
+                    a: if visible { scroller_alpha } else { 0.0 },
+                    ..palette.text_secondary
+                }),
+                border: Border {
+                    radius: RADIUS_SMALL.into(),
+                    ..Default::default()
+                },
+            },
+        };
+
+        scrollable::Style {
+            container: container::Style::default(),
+            vertical_rail: rail(true),
+            horizontal_rail: rail(true),
+            gap: None,
+            auto_scroll: scrollable::AutoScroll {
+                background: Background::Color(Color::TRANSPARENT),
+                border: Border::default(),
+                shadow: Shadow::default(),
+                icon: Color::TRANSPARENT,
+            },
+        }
     }
 }

--- a/src/terminal/theme.rs
+++ b/src/terminal/theme.rs
@@ -88,8 +88,7 @@ fn parse_hex(s: &str) -> Option<[u8; 3]> {
 
 static ALL_PRESETS: OnceLock<Vec<ColorPreset>> = OnceLock::new();
 
-/// Returns all color presets (built-in + user custom themes).
-/// Loaded once on first call and cached for the lifetime of the process.
+/// Returns all color presets (built-in + user custom themes)
 pub fn all_presets() -> &'static [ColorPreset] {
     ALL_PRESETS.get_or_init(|| {
         let mut presets = builtin_presets();
@@ -464,12 +463,9 @@ pub(super) fn resolve_rgb(
 }
 
 /// Minimum WCAG contrast ratio for terminal text readability.
-/// 3.0 is a good balance - ensures dark blue/red are visible on dark backgrounds
-/// without washing out intentionally dim colors too aggressively.
 const MIN_CONTRAST_RATIO: f32 = 3.0;
 
 /// Ensure foreground has minimum contrast against background.
-/// If contrast is too low, lightens or darkens fg until the ratio is met.
 pub(super) fn enforce_min_contrast(fg: Rgb, bg: Rgb) -> Rgb {
     let fg_lum = relative_luminance(fg);
     let bg_lum = relative_luminance(bg);

--- a/src/terminal/theme.rs
+++ b/src/terminal/theme.rs
@@ -2,6 +2,8 @@ use crate::config::AppConfig;
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::color::Colors;
 use alacritty_terminal::vte::ansi::{Color as AnsiColor, NamedColor, Rgb};
+use serde::Deserialize;
+use std::sync::OnceLock;
 
 #[derive(Debug, Clone)]
 pub struct TerminalTheme {
@@ -12,193 +14,333 @@ pub struct TerminalTheme {
 }
 
 /// A named color preset with foreground, background, cursor, and 16 ANSI colors.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ColorPreset {
-    pub name: &'static str,
+    pub name: String,
     pub fg: [u8; 3],
     pub bg: [u8; 3],
     pub cursor: [u8; 3],
     pub ansi: [[u8; 3]; 16],
 }
 
-pub const PRESETS: &[ColorPreset] = &[
-    ColorPreset {
-        name: "Catppuccin Mocha",
-        fg: [0xcd, 0xd6, 0xf4],
-        bg: [0x1e, 0x1e, 0x2e],
-        cursor: [0xf5, 0xe0, 0xdc],
-        ansi: [
-            [0x45, 0x47, 0x5a], // black
-            [0xf3, 0x8b, 0xa8], // red
-            [0xa6, 0xe3, 0xa1], // green
-            [0xf9, 0xe2, 0xaf], // yellow
-            [0x89, 0xb4, 0xfa], // blue
-            [0xf5, 0xc2, 0xe7], // magenta
-            [0x94, 0xe2, 0xd5], // cyan
-            [0xba, 0xc2, 0xde], // white
-            [0x58, 0x5b, 0x70], // bright black
-            [0xf3, 0x8b, 0xa8], // bright red
-            [0xa6, 0xe3, 0xa1], // bright green
-            [0xf9, 0xe2, 0xaf], // bright yellow
-            [0x89, 0xb4, 0xfa], // bright blue
-            [0xf5, 0xc2, 0xe7], // bright magenta
-            [0x94, 0xe2, 0xd5], // bright cyan
-            [0xa6, 0xad, 0xc8], // bright white
-        ],
-    },
-    ColorPreset {
-        name: "Dracula",
-        fg: [0xf8, 0xf8, 0xf2],
-        bg: [0x28, 0x2a, 0x36],
-        cursor: [0xf8, 0xf8, 0xf2],
-        ansi: [
-            [0x21, 0x22, 0x2c], // black
-            [0xff, 0x55, 0x55], // red
-            [0x50, 0xfa, 0x7b], // green
-            [0xf1, 0xfa, 0x8c], // yellow
-            [0xbd, 0x93, 0xf9], // blue
-            [0xff, 0x79, 0xc6], // magenta
-            [0x8b, 0xe9, 0xfd], // cyan
-            [0xf8, 0xf8, 0xf2], // white
-            [0x62, 0x72, 0xa4], // bright black
-            [0xff, 0x6e, 0x6e], // bright red
-            [0x69, 0xff, 0x94], // bright green
-            [0xff, 0xff, 0xa5], // bright yellow
-            [0xd6, 0xac, 0xff], // bright blue
-            [0xff, 0x92, 0xdf], // bright magenta
-            [0xa4, 0xff, 0xff], // bright cyan
-            [0xff, 0xff, 0xff], // bright white
-        ],
-    },
-    ColorPreset {
-        name: "Tokyo Night",
-        fg: [0xa9, 0xb1, 0xd6],
-        bg: [0x1a, 0x1b, 0x26],
-        cursor: [0xc0, 0xca, 0xf5],
-        ansi: [
-            [0x15, 0x16, 0x1e], // black
-            [0xf7, 0x76, 0x8e], // red
-            [0x9e, 0xce, 0x6a], // green
-            [0xe0, 0xaf, 0x68], // yellow
-            [0x7a, 0xa2, 0xf7], // blue
-            [0xbb, 0x9a, 0xf7], // magenta
-            [0x7d, 0xcf, 0xff], // cyan
-            [0xa9, 0xb1, 0xd6], // white
-            [0x41, 0x48, 0x68], // bright black
-            [0xf7, 0x76, 0x8e], // bright red
-            [0x9e, 0xce, 0x6a], // bright green
-            [0xe0, 0xaf, 0x68], // bright yellow
-            [0x7a, 0xa2, 0xf7], // bright blue
-            [0xbb, 0x9a, 0xf7], // bright magenta
-            [0x7d, 0xcf, 0xff], // bright cyan
-            [0xc0, 0xca, 0xf5], // bright white
-        ],
-    },
-    ColorPreset {
-        name: "Nord",
-        fg: [0xd8, 0xde, 0xe9],
-        bg: [0x2e, 0x34, 0x40],
-        cursor: [0xd8, 0xde, 0xe9],
-        ansi: [
-            [0x3b, 0x42, 0x52], // black
-            [0xbf, 0x61, 0x6a], // red
-            [0xa3, 0xbe, 0x8c], // green
-            [0xeb, 0xcb, 0x8b], // yellow
-            [0x81, 0xa1, 0xc1], // blue
-            [0xb4, 0x8e, 0xad], // magenta
-            [0x88, 0xc0, 0xd0], // cyan
-            [0xe5, 0xe9, 0xf0], // white
-            [0x4c, 0x56, 0x6a], // bright black
-            [0xbf, 0x61, 0x6a], // bright red
-            [0xa3, 0xbe, 0x8c], // bright green
-            [0xeb, 0xcb, 0x8b], // bright yellow
-            [0x81, 0xa1, 0xc1], // bright blue
-            [0xb4, 0x8e, 0xad], // bright magenta
-            [0x8f, 0xbc, 0xbb], // bright cyan
-            [0xec, 0xef, 0xf4], // bright white
-        ],
-    },
-    ColorPreset {
-        name: "One Dark",
-        fg: [0xab, 0xb2, 0xbf],
-        bg: [0x28, 0x2c, 0x34],
-        cursor: [0x52, 0x8b, 0xff],
-        ansi: [
-            [0x28, 0x2c, 0x34], // black
-            [0xe0, 0x6c, 0x75], // red
-            [0x98, 0xc3, 0x79], // green
-            [0xe5, 0xc0, 0x7b], // yellow
-            [0x61, 0xaf, 0xef], // blue
-            [0xc6, 0x78, 0xdd], // magenta
-            [0x56, 0xb6, 0xc2], // cyan
-            [0xab, 0xb2, 0xbf], // white
-            [0x54, 0x58, 0x62], // bright black
-            [0xe0, 0x6c, 0x75], // bright red
-            [0x98, 0xc3, 0x79], // bright green
-            [0xe5, 0xc0, 0x7b], // bright yellow
-            [0x61, 0xaf, 0xef], // bright blue
-            [0xc6, 0x78, 0xdd], // bright magenta
-            [0x56, 0xb6, 0xc2], // bright cyan
-            [0xff, 0xff, 0xff], // bright white
-        ],
-    },
-    ColorPreset {
-        name: "Gruvbox Dark",
-        fg: [0xeb, 0xdb, 0xb2],
-        bg: [0x28, 0x28, 0x28],
-        cursor: [0xeb, 0xdb, 0xb2],
-        ansi: [
-            [0x28, 0x28, 0x28], // black
-            [0xcc, 0x24, 0x1d], // red
-            [0x98, 0x97, 0x1a], // green
-            [0xd7, 0x99, 0x21], // yellow
-            [0x45, 0x85, 0x88], // blue
-            [0xb1, 0x62, 0x86], // magenta
-            [0x68, 0x9d, 0x6a], // cyan
-            [0xa8, 0x99, 0x84], // white
-            [0x92, 0x83, 0x74], // bright black
-            [0xfb, 0x49, 0x34], // bright red
-            [0xb8, 0xbb, 0x26], // bright green
-            [0xfa, 0xbd, 0x2f], // bright yellow
-            [0x83, 0xa5, 0x98], // bright blue
-            [0xd3, 0x86, 0x9b], // bright magenta
-            [0x8e, 0xc0, 0x7c], // bright cyan
-            [0xeb, 0xdb, 0xb2], // bright white
-        ],
-    },
-    ColorPreset {
-        name: "Solarized Dark",
-        fg: [0x83, 0x94, 0x96],
-        bg: [0x00, 0x2b, 0x36],
-        cursor: [0x83, 0x94, 0x96],
-        ansi: [
-            [0x07, 0x36, 0x42], // black
-            [0xdc, 0x32, 0x2f], // red
-            [0x85, 0x99, 0x00], // green
-            [0xb5, 0x89, 0x00], // yellow
-            [0x26, 0x8b, 0xd2], // blue
-            [0xd3, 0x36, 0x82], // magenta
-            [0x2a, 0xa1, 0x98], // cyan
-            [0xee, 0xe8, 0xd5], // white
-            [0x00, 0x2b, 0x36], // bright black
-            [0xcb, 0x4b, 0x16], // bright red
-            [0x58, 0x6e, 0x75], // bright green
-            [0x65, 0x7b, 0x83], // bright yellow
-            [0x83, 0x94, 0x96], // bright blue
-            [0x6c, 0x71, 0xc4], // bright magenta
-            [0x93, 0xa1, 0xa1], // bright cyan
-            [0xfd, 0xf6, 0xe3], // bright white
-        ],
-    },
-];
+/// TOML representation of a custom theme file.
+#[derive(Debug, Deserialize)]
+struct ThemeToml {
+    name: String,
+    foreground: String,
+    background: String,
+    cursor: String,
+    ansi: AnsiToml,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnsiToml {
+    black: String,
+    red: String,
+    green: String,
+    yellow: String,
+    blue: String,
+    magenta: String,
+    cyan: String,
+    white: String,
+    bright_black: String,
+    bright_red: String,
+    bright_green: String,
+    bright_yellow: String,
+    bright_blue: String,
+    bright_magenta: String,
+    bright_cyan: String,
+    bright_white: String,
+}
+
+impl ThemeToml {
+    fn to_preset(&self) -> Option<ColorPreset> {
+        Some(ColorPreset {
+            name: self.name.clone(),
+            fg: parse_hex(&self.foreground)?,
+            bg: parse_hex(&self.background)?,
+            cursor: parse_hex(&self.cursor)?,
+            ansi: [
+                parse_hex(&self.ansi.black)?,
+                parse_hex(&self.ansi.red)?,
+                parse_hex(&self.ansi.green)?,
+                parse_hex(&self.ansi.yellow)?,
+                parse_hex(&self.ansi.blue)?,
+                parse_hex(&self.ansi.magenta)?,
+                parse_hex(&self.ansi.cyan)?,
+                parse_hex(&self.ansi.white)?,
+                parse_hex(&self.ansi.bright_black)?,
+                parse_hex(&self.ansi.bright_red)?,
+                parse_hex(&self.ansi.bright_green)?,
+                parse_hex(&self.ansi.bright_yellow)?,
+                parse_hex(&self.ansi.bright_blue)?,
+                parse_hex(&self.ansi.bright_magenta)?,
+                parse_hex(&self.ansi.bright_cyan)?,
+                parse_hex(&self.ansi.bright_white)?,
+            ],
+        })
+    }
+}
+
+fn parse_hex(s: &str) -> Option<[u8; 3]> {
+    crate::config::parse_hex_color(s)
+}
+
+static ALL_PRESETS: OnceLock<Vec<ColorPreset>> = OnceLock::new();
+
+/// Returns all color presets (built-in + user custom themes).
+/// Loaded once on first call and cached for the lifetime of the process.
+pub fn all_presets() -> &'static [ColorPreset] {
+    ALL_PRESETS.get_or_init(|| {
+        let mut presets = builtin_presets();
+        let custom = load_custom_presets();
+        for cp in custom {
+            // Custom themes override built-in themes with the same name
+            if let Some(existing) = presets
+                .iter_mut()
+                .find(|p| p.name.eq_ignore_ascii_case(&cp.name))
+            {
+                *existing = cp;
+            } else {
+                presets.push(cp);
+            }
+        }
+        presets
+    })
+}
+
+#[allow(dead_code)]
+pub fn reload_presets() {
+    let _ = all_presets();
+}
 
 pub fn find_preset(name: &str) -> Option<&'static ColorPreset> {
-    PRESETS.iter().find(|p| p.name.eq_ignore_ascii_case(name))
+    all_presets()
+        .iter()
+        .find(|p| p.name.eq_ignore_ascii_case(name))
+}
+
+fn load_custom_presets() -> Vec<ColorPreset> {
+    let Some(themes_dir) = dirs::config_dir().map(|d| d.join("rabbitty").join("themes")) else {
+        return vec![];
+    };
+    let Ok(entries) = std::fs::read_dir(&themes_dir) else {
+        return vec![];
+    };
+    let mut presets = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "toml") {
+            match std::fs::read_to_string(&path) {
+                Ok(content) => match toml::from_str::<ThemeToml>(&content) {
+                    Ok(theme_toml) => {
+                        if let Some(preset) = theme_toml.to_preset() {
+                            presets.push(preset);
+                        } else {
+                            eprintln!(
+                                "Warning: invalid color values in theme file: {}",
+                                path.display()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: failed to parse theme file {}: {}",
+                            path.display(),
+                            e
+                        );
+                    }
+                },
+                Err(e) => {
+                    eprintln!(
+                        "Warning: failed to read theme file {}: {}",
+                        path.display(),
+                        e
+                    );
+                }
+            }
+        }
+    }
+    presets
+}
+
+fn builtin_presets() -> Vec<ColorPreset> {
+    vec![
+        ColorPreset {
+            name: "Catppuccin Mocha".into(),
+            fg: [0xcd, 0xd6, 0xf4],
+            bg: [0x1e, 0x1e, 0x2e],
+            cursor: [0xf5, 0xe0, 0xdc],
+            ansi: [
+                [0x45, 0x47, 0x5a], // black
+                [0xf3, 0x8b, 0xa8], // red
+                [0xa6, 0xe3, 0xa1], // green
+                [0xf9, 0xe2, 0xaf], // yellow
+                [0x89, 0xb4, 0xfa], // blue
+                [0xf5, 0xc2, 0xe7], // magenta
+                [0x94, 0xe2, 0xd5], // cyan
+                [0xba, 0xc2, 0xde], // white
+                [0x58, 0x5b, 0x70], // bright black
+                [0xf3, 0x8b, 0xa8], // bright red
+                [0xa6, 0xe3, 0xa1], // bright green
+                [0xf9, 0xe2, 0xaf], // bright yellow
+                [0x89, 0xb4, 0xfa], // bright blue
+                [0xf5, 0xc2, 0xe7], // bright magenta
+                [0x94, 0xe2, 0xd5], // bright cyan
+                [0xa6, 0xad, 0xc8], // bright white
+            ],
+        },
+        ColorPreset {
+            name: "Dracula".into(),
+            fg: [0xf8, 0xf8, 0xf2],
+            bg: [0x28, 0x2a, 0x36],
+            cursor: [0xf8, 0xf8, 0xf2],
+            ansi: [
+                [0x21, 0x22, 0x2c], // black
+                [0xff, 0x55, 0x55], // red
+                [0x50, 0xfa, 0x7b], // green
+                [0xf1, 0xfa, 0x8c], // yellow
+                [0xbd, 0x93, 0xf9], // blue
+                [0xff, 0x79, 0xc6], // magenta
+                [0x8b, 0xe9, 0xfd], // cyan
+                [0xf8, 0xf8, 0xf2], // white
+                [0x62, 0x72, 0xa4], // bright black
+                [0xff, 0x6e, 0x6e], // bright red
+                [0x69, 0xff, 0x94], // bright green
+                [0xff, 0xff, 0xa5], // bright yellow
+                [0xd6, 0xac, 0xff], // bright blue
+                [0xff, 0x92, 0xdf], // bright magenta
+                [0xa4, 0xff, 0xff], // bright cyan
+                [0xff, 0xff, 0xff], // bright white
+            ],
+        },
+        ColorPreset {
+            name: "Tokyo Night".into(),
+            fg: [0xa9, 0xb1, 0xd6],
+            bg: [0x1a, 0x1b, 0x26],
+            cursor: [0xc0, 0xca, 0xf5],
+            ansi: [
+                [0x15, 0x16, 0x1e], // black
+                [0xf7, 0x76, 0x8e], // red
+                [0x9e, 0xce, 0x6a], // green
+                [0xe0, 0xaf, 0x68], // yellow
+                [0x7a, 0xa2, 0xf7], // blue
+                [0xbb, 0x9a, 0xf7], // magenta
+                [0x7d, 0xcf, 0xff], // cyan
+                [0xa9, 0xb1, 0xd6], // white
+                [0x41, 0x48, 0x68], // bright black
+                [0xf7, 0x76, 0x8e], // bright red
+                [0x9e, 0xce, 0x6a], // bright green
+                [0xe0, 0xaf, 0x68], // bright yellow
+                [0x7a, 0xa2, 0xf7], // bright blue
+                [0xbb, 0x9a, 0xf7], // bright magenta
+                [0x7d, 0xcf, 0xff], // bright cyan
+                [0xc0, 0xca, 0xf5], // bright white
+            ],
+        },
+        ColorPreset {
+            name: "Nord".into(),
+            fg: [0xd8, 0xde, 0xe9],
+            bg: [0x2e, 0x34, 0x40],
+            cursor: [0xd8, 0xde, 0xe9],
+            ansi: [
+                [0x3b, 0x42, 0x52], // black
+                [0xbf, 0x61, 0x6a], // red
+                [0xa3, 0xbe, 0x8c], // green
+                [0xeb, 0xcb, 0x8b], // yellow
+                [0x81, 0xa1, 0xc1], // blue
+                [0xb4, 0x8e, 0xad], // magenta
+                [0x88, 0xc0, 0xd0], // cyan
+                [0xe5, 0xe9, 0xf0], // white
+                [0x4c, 0x56, 0x6a], // bright black
+                [0xbf, 0x61, 0x6a], // bright red
+                [0xa3, 0xbe, 0x8c], // bright green
+                [0xeb, 0xcb, 0x8b], // bright yellow
+                [0x81, 0xa1, 0xc1], // bright blue
+                [0xb4, 0x8e, 0xad], // bright magenta
+                [0x8f, 0xbc, 0xbb], // bright cyan
+                [0xec, 0xef, 0xf4], // bright white
+            ],
+        },
+        ColorPreset {
+            name: "One Dark".into(),
+            fg: [0xab, 0xb2, 0xbf],
+            bg: [0x28, 0x2c, 0x34],
+            cursor: [0x52, 0x8b, 0xff],
+            ansi: [
+                [0x28, 0x2c, 0x34], // black
+                [0xe0, 0x6c, 0x75], // red
+                [0x98, 0xc3, 0x79], // green
+                [0xe5, 0xc0, 0x7b], // yellow
+                [0x61, 0xaf, 0xef], // blue
+                [0xc6, 0x78, 0xdd], // magenta
+                [0x56, 0xb6, 0xc2], // cyan
+                [0xab, 0xb2, 0xbf], // white
+                [0x54, 0x58, 0x62], // bright black
+                [0xe0, 0x6c, 0x75], // bright red
+                [0x98, 0xc3, 0x79], // bright green
+                [0xe5, 0xc0, 0x7b], // bright yellow
+                [0x61, 0xaf, 0xef], // bright blue
+                [0xc6, 0x78, 0xdd], // bright magenta
+                [0x56, 0xb6, 0xc2], // bright cyan
+                [0xff, 0xff, 0xff], // bright white
+            ],
+        },
+        ColorPreset {
+            name: "Gruvbox Dark".into(),
+            fg: [0xeb, 0xdb, 0xb2],
+            bg: [0x28, 0x28, 0x28],
+            cursor: [0xeb, 0xdb, 0xb2],
+            ansi: [
+                [0x28, 0x28, 0x28], // black
+                [0xcc, 0x24, 0x1d], // red
+                [0x98, 0x97, 0x1a], // green
+                [0xd7, 0x99, 0x21], // yellow
+                [0x45, 0x85, 0x88], // blue
+                [0xb1, 0x62, 0x86], // magenta
+                [0x68, 0x9d, 0x6a], // cyan
+                [0xa8, 0x99, 0x84], // white
+                [0x92, 0x83, 0x74], // bright black
+                [0xfb, 0x49, 0x34], // bright red
+                [0xb8, 0xbb, 0x26], // bright green
+                [0xfa, 0xbd, 0x2f], // bright yellow
+                [0x83, 0xa5, 0x98], // bright blue
+                [0xd3, 0x86, 0x9b], // bright magenta
+                [0x8e, 0xc0, 0x7c], // bright cyan
+                [0xeb, 0xdb, 0xb2], // bright white
+            ],
+        },
+        ColorPreset {
+            name: "Solarized Dark".into(),
+            fg: [0x83, 0x94, 0x96],
+            bg: [0x00, 0x2b, 0x36],
+            cursor: [0x83, 0x94, 0x96],
+            ansi: [
+                [0x07, 0x36, 0x42], // black
+                [0xdc, 0x32, 0x2f], // red
+                [0x85, 0x99, 0x00], // green
+                [0xb5, 0x89, 0x00], // yellow
+                [0x26, 0x8b, 0xd2], // blue
+                [0xd3, 0x36, 0x82], // magenta
+                [0x2a, 0xa1, 0x98], // cyan
+                [0xee, 0xe8, 0xd5], // white
+                [0x00, 0x2b, 0x36], // bright black
+                [0xcb, 0x4b, 0x16], // bright red
+                [0x58, 0x6e, 0x75], // bright green
+                [0x65, 0x7b, 0x83], // bright yellow
+                [0x83, 0x94, 0x96], // bright blue
+                [0x6c, 0x71, 0xc4], // bright magenta
+                [0x93, 0xa1, 0xa1], // bright cyan
+                [0xfd, 0xf6, 0xe3], // bright white
+            ],
+        },
+    ]
 }
 
 impl Default for TerminalTheme {
     fn default() -> Self {
-        let preset = &PRESETS[0]; // Catppuccin Mocha
+        let presets = all_presets();
+        let preset = &presets[0]; // Catppuccin Mocha
         Self {
             foreground: rgb_from_triplet(preset.fg),
             background: rgb_from_triplet(preset.bg),
@@ -215,7 +357,7 @@ impl TerminalTheme {
         } else if let Some(ref ansi) = config.theme.ansi_colors {
             ansi.map(rgb_from_triplet)
         } else {
-            PRESETS[0].ansi.map(rgb_from_triplet)
+            all_presets()[0].ansi.map(rgb_from_triplet)
         };
 
         Self {


### PR DESCRIPTION
Resolves #75

## Summary
- UI palette derived dynamically from `ThemeConfig` — no more hardcoded `Palette::DARK`
- Custom color themes via `~/.config/rabbitty/themes/*.toml`
- Grayscale AA replaces subpixel rendering (fixes text outline fringing on transparent backgrounds)
- Fix settings tab overflow panic (`SETTINGS_TAB_INDEX + 1`)

## Test plan
- [ ] Change theme in settings → verify sidebar/header/inputs update dynamically
- [ ] Add a custom `.toml` theme file → verify it appears in theme picker
- [ ] Set background opacity < 1.0 → verify no text color fringing