### PR TITLE
refactor: neutral UI chrome

### DIFF
--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -7,7 +7,7 @@ mod shell_picker;
 pub(in crate::gui) use dialog::{DialogButton, confirm_dialog};
 
 use super::{App, Message, SETTINGS_TAB_INDEX};
-use crate::gui::components::{button_primary, panel, tab_bar};
+use crate::gui::components::{button_secondary, panel, tab_bar};
 use crate::gui::render::TerminalProgram;
 use iced::widget::{column, container, image, row, scrollable, stack, text};
 use iced::{Alignment, Element, Length};
@@ -62,7 +62,8 @@ impl App {
             let version_label = text(format!("RabbiTTY v{}", env!("CARGO_PKG_VERSION")))
                 .size(13)
                 .color(iced::Color::from_rgba(1.0, 1.0, 1.0, 0.4));
-            let new_tab_btn = button_primary("New Tab", palette).on_press(Message::OpenShellPicker);
+            let new_tab_btn =
+                button_secondary("New Tab", palette).on_press(Message::OpenShellPicker);
             container(
                 column![logo, version_label, new_tab_btn]
                     .spacing(12)

--- a/src/gui/app/view/settings.rs
+++ b/src/gui/app/view/settings.rs
@@ -17,13 +17,13 @@ impl App {
             let button_style = move |_theme: &iced::Theme, status: iced::widget::button::Status| {
                 let bg = if is_active {
                     Color {
-                        a: 0.15,
-                        ..palette.accent
+                        a: 0.12,
+                        ..palette.text
                     }
                 } else {
                     match status {
                         iced::widget::button::Status::Hovered => Color {
-                            a: 0.1,
+                            a: 0.08,
                             ..palette.text
                         },
                         _ => Color::TRANSPARENT,
@@ -33,7 +33,7 @@ impl App {
                 iced::widget::button::Style {
                     background: Some(Background::Color(bg)),
                     text_color: if is_active {
-                        palette.accent
+                        palette.text
                     } else {
                         palette.text_secondary
                     },
@@ -80,7 +80,7 @@ impl App {
             }),
             text(self.settings_category.label())
                 .size(16)
-                .color(palette.accent),
+                .color(palette.text),
         ]
         .align_y(iced::Alignment::Center)
         .spacing(SPACING_SMALL);

--- a/src/gui/app/view/shell_picker.rs
+++ b/src/gui/app/view/shell_picker.rs
@@ -183,16 +183,9 @@ fn picker_item(
     let mut content_items: Vec<Element<'static, Message>> = vec![
         text(label)
             .size(13)
-            .color(if selected {
-                Color {
-                    a: alpha,
-                    ..palette.background
-                }
-            } else {
-                Color {
-                    a: alpha,
-                    ..palette.text
-                }
+            .color(Color {
+                a: alpha,
+                ..palette.text
             })
             .into(),
     ];
@@ -201,16 +194,9 @@ fn picker_item(
         content_items.push(
             text(sub)
                 .size(10)
-                .color(if selected {
-                    Color {
-                        a: 0.7 * alpha,
-                        ..palette.background
-                    }
-                } else {
-                    Color {
-                        a: alpha * 0.7,
-                        ..palette.text_secondary
-                    }
+                .color(Color {
+                    a: alpha * 0.7,
+                    ..palette.text_secondary
                 })
                 .into(),
         );
@@ -225,12 +211,12 @@ fn picker_item(
                 if selected {
                     iced::widget::button::Style {
                         background: Some(Background::Color(Color {
-                            a: alpha,
-                            ..palette.accent
+                            a: 0.15 * alpha,
+                            ..palette.text
                         })),
                         text_color: Color {
                             a: alpha,
-                            ..palette.background
+                            ..palette.text
                         },
                         border: Border {
                             radius: RADIUS_SMALL.into(),

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -25,8 +25,8 @@ pub fn tab_bar<'a>(
             let gap = container(text("")).width(24).height(Length::Shrink).style(
                 move |_theme: &Theme| container::Style {
                     background: Some(Background::Color(Color {
-                        a: 0.2,
-                        ..palette.accent
+                        a: 0.15,
+                        ..palette.text
                     })),
                     border: Border {
                         radius: 4.0.into(),
@@ -276,13 +276,15 @@ fn browser_tab<'a>(
     );
 
     if is_active {
-        // Active tab with bottom accent indicator
         let indicator =
             container(text(""))
                 .width(Length::Fill)
                 .height(2)
                 .style(move |_theme: &Theme| container::Style {
-                    background: Some(Background::Color(palette.accent)),
+                    background: Some(Background::Color(Color {
+                        a: 0.6,
+                        ..palette.text
+                    })),
                     ..Default::default()
                 });
 

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -477,14 +477,14 @@ pub fn section<'a>(
 ) -> Element<'a, Message> {
     container(
         column(vec![
-            text(title).size(14).color(palette.accent).into(),
+            text(title).size(14).color(palette.text).into(),
             container("")
                 .width(Length::Fill)
                 .height(Length::Fixed(1.0))
                 .style(move |_theme: &iced::Theme| container::Style {
                     background: Some(Background::Color(Color {
-                        a: 0.15,
-                        ..palette.accent
+                        a: 0.10,
+                        ..palette.text
                     })),
                     ..Default::default()
                 })

--- a/src/gui/settings/ssh.rs
+++ b/src/gui/settings/ssh.rs
@@ -71,7 +71,7 @@ fn profile_card<'a>(
     };
 
     let title_row = row![
-        text(title).size(14).color(palette.accent),
+        text(title).size(14).color(palette.text),
         container("").width(Length::Fill),
         button_secondary("Remove", palette).on_press(Message::RemoveSshProfile(index)),
     ]
@@ -83,8 +83,8 @@ fn profile_card<'a>(
         .height(Length::Fixed(1.0))
         .style(move |_theme: &iced::Theme| iced::widget::container::Style {
             background: Some(Background::Color(Color {
-                a: 0.10,
-                ..palette.accent
+                a: 0.08,
+                ..palette.text
             })),
             ..Default::default()
         });


### PR DESCRIPTION
Resolves #77

## Summary
- Replace accent color with neutral gray tones across UI chrome
- Sidebar, section headers, tab indicator, breadcrumb, shell picker, SSH cards, lobby button all neutralized
- Accent reserved for primary buttons and input focus borders only

## Test plan
- [x] Switch between different themes → verify UI elements stay neutral
- [x] Check shell picker, settings sidebar, tab bar across themes