### PR TITLE
feat: 로비 화면에 최근 세션 히스토리 표시

### DIFF
--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -4,6 +4,7 @@ use crate::gui::settings::{
 };
 use crate::gui::tab::{ShellKind, TerminalTab, discover_available_shells};
 use crate::session::OutputEvent;
+use crate::session_history::SessionHistory;
 use crate::terminal::font::discover_system_terminal_fonts;
 use iced::Animation;
 use iced::Size;
@@ -45,6 +46,7 @@ pub enum Message {
     CloseSshProfileModal,
     SaveSshProfileModal,
     CreateSshTab(usize),
+    LaunchFromHistory(usize),
     #[cfg(target_os = "macos")]
     ConfirmRestartForBlur,
     #[cfg(target_os = "macos")]
@@ -126,6 +128,7 @@ pub struct App {
     pub(super) palette: crate::gui::theme::Palette,
     pub(super) ime_active: bool,
     pub(super) ime_preedit: Option<(String, Option<std::ops::Range<usize>>)>,
+    pub(super) session_history: SessionHistory,
     pub(super) window_style_applied: bool,
     #[cfg(target_os = "macos")]
     pub(super) show_restart_confirm: bool,
@@ -170,6 +173,7 @@ impl App {
             resize_debounce_pending: false,
             resize_debounce_seq: 0,
             resize_debounce_spawned_seq: 0,
+            session_history: SessionHistory::load(),
             palette,
             ime_active: false,
             ime_preedit: None,

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -119,6 +119,28 @@ impl App {
                     return self.create_tab(shell);
                 }
             }
+            Message::LaunchFromHistory(index) => {
+                if let Some(entry) = self.session_history.entries.get(index).cloned() {
+                    use crate::session_history::SessionKind;
+                    let shell = match entry.kind {
+                        SessionKind::Default => ShellKind::Default,
+                        SessionKind::Shell { name, path } => ShellKind::Shell { name, path },
+                        SessionKind::Ssh { host, port, user } => {
+                            if let Some(profile) = self
+                                .config
+                                .ssh_profiles
+                                .iter()
+                                .find(|p| p.host == host && p.port == port && p.user == user)
+                            {
+                                ShellKind::Ssh(profile.clone())
+                            } else {
+                                return Task::none();
+                            }
+                        }
+                    };
+                    return self.create_tab(shell);
+                }
+            }
 
             // ── Settings ────────────────────────────────────────────
             Message::AddSshProfile => {

--- a/src/gui/app/update/tab.rs
+++ b/src/gui/app/update/tab.rs
@@ -3,6 +3,7 @@ use super::super::{App, Message, SETTINGS_TAB_INDEX};
 use crate::config::SshProfile;
 use crate::gui::settings::SettingsDraft;
 use crate::gui::tab::ShellKind;
+use crate::session_history::SessionKind;
 use crate::terminal::TerminalTheme;
 use iced::Task;
 use iced::keyboard::{Key, Modifiers};
@@ -18,9 +19,23 @@ impl App {
         let theme = TerminalTheme::from_config(&self.config);
         let tab_id = self.next_tab_id;
         self.next_tab_id = self.next_tab_id.wrapping_add(1);
+        let history_kind = match &shell {
+            ShellKind::Default => SessionKind::Default,
+            ShellKind::Shell { name, path } => SessionKind::Shell {
+                name: name.clone(),
+                path: path.clone(),
+            },
+            ShellKind::Ssh(p) => SessionKind::Ssh {
+                host: p.host.clone(),
+                port: p.port,
+                user: p.user.clone(),
+            },
+        };
+        let display_name = shell.display_name();
         let new_tab =
             crate::gui::tab::TerminalTab::from_shell(shell, cols, rows, theme, tab_id, sender);
         self.tabs.push(new_tab);
+        self.session_history.record(history_kind, display_name);
         self.active_tab = self.tabs.len() - 1;
         self.show_shell_picker = false;
         self.shell_picker_selected = 0;

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -10,8 +10,9 @@ use super::{App, Message, SETTINGS_TAB_INDEX};
 use crate::gui::components::ime_wrapper::ImeEnabled;
 use crate::gui::components::{button_secondary, panel, tab_bar};
 use crate::gui::render::TerminalProgram;
-use iced::widget::{column, container, image, row, scrollable, stack, text};
-use iced::{Alignment, Element, Length};
+use crate::gui::theme::{RADIUS_SMALL, SPACING_SMALL};
+use iced::widget::{button, column, container, image, row, scrollable, stack, text};
+use iced::{Alignment, Background, Border, Color, Element, Length};
 use std::sync::LazyLock;
 
 static LOGO_HANDLE: LazyLock<image::Handle> =
@@ -57,21 +58,7 @@ impl App {
         } else if let Some(active_tab) = self.tabs.get(self.active_tab) {
             self.view_terminal(active_tab)
         } else {
-            let logo = image(LOGO_HANDLE.clone())
-                .width(Length::Fixed(96.0))
-                .height(Length::Fixed(96.0));
-            let version_label = text(format!("RabbiTTY v{}", env!("CARGO_PKG_VERSION")))
-                .size(13)
-                .color(iced::Color::from_rgba(1.0, 1.0, 1.0, 0.4));
-            let new_tab_btn =
-                button_secondary("New Tab", palette).on_press(Message::OpenShellPicker);
-            container(
-                column![logo, version_label, new_tab_btn]
-                    .spacing(12)
-                    .align_x(Alignment::Center),
-            )
-            .center(Length::Fill)
-            .into()
+            self.view_lobby(palette)
         };
 
         let panel_background = Some(self.theme_background_color());
@@ -176,5 +163,93 @@ impl App {
         ImeEnabled::new(terminal_view)
             .preedit(self.ime_preedit.clone())
             .into()
+    }
+
+    fn view_lobby(&self, palette: crate::gui::theme::Palette) -> Element<'_, Message> {
+        let logo = image(LOGO_HANDLE.clone())
+            .width(Length::Fixed(96.0))
+            .height(Length::Fixed(96.0));
+        let version_label = text(format!("RabbiTTY v{}", env!("CARGO_PKG_VERSION")))
+            .size(13)
+            .color(Color::from_rgba(1.0, 1.0, 1.0, 0.4));
+        let new_tab_btn =
+            button_secondary("New Tab", palette).on_press(Message::OpenShellPicker);
+
+        let mut content: Vec<Element<Message>> = vec![
+            logo.into(),
+            version_label.into(),
+            new_tab_btn.into(),
+        ];
+
+        if !self.session_history.entries.is_empty() {
+            content.push(
+                container(text(""))
+                    .width(Length::Fixed(240.0))
+                    .height(1)
+                    .style(move |_theme: &iced::Theme| container::Style {
+                        background: Some(Background::Color(Color {
+                            a: 0.1,
+                            ..palette.text
+                        })),
+                        ..Default::default()
+                    })
+                    .into(),
+            );
+            content.push(
+                text("Recent Sessions")
+                    .size(11)
+                    .color(Color { a: 0.5, ..palette.text_secondary })
+                    .into(),
+            );
+
+            for (i, entry) in self.session_history.entries.iter().enumerate() {
+                let name = entry.display_name.clone();
+                let kind_label = match &entry.kind {
+                    crate::session_history::SessionKind::Default => "Default Shell",
+                    crate::session_history::SessionKind::Shell { .. } => "Shell",
+                    crate::session_history::SessionKind::Ssh { .. } => "SSH",
+                };
+
+                let label_col = column![
+                    text(name).size(13).color(Color { a: 0.9, ..palette.text }),
+                    text(kind_label).size(10).color(Color { a: 0.5, ..palette.text_secondary }),
+                ]
+                .spacing(1);
+
+                content.push(
+                    button(label_col)
+                        .style(move |_theme: &iced::Theme, status: iced::widget::button::Status| {
+                            let hovered = matches!(status, iced::widget::button::Status::Hovered);
+                            iced::widget::button::Style {
+                                background: Some(Background::Color(if hovered {
+                                    Color { a: 0.08, ..palette.text }
+                                } else {
+                                    Color::TRANSPARENT
+                                })),
+                                text_color: palette.text,
+                                border: Border {
+                                    radius: RADIUS_SMALL.into(),
+                                    width: 0.0,
+                                    color: Color::TRANSPARENT,
+                                },
+                                shadow: iced::Shadow::default(),
+                                snap: false,
+                            }
+                        })
+                        .padding([6, 10])
+                        .width(Length::Fixed(240.0))
+                        .on_press(Message::LaunchFromHistory(i))
+                        .into(),
+                );
+            }
+        }
+
+        container(
+            column(content)
+                .spacing(SPACING_SMALL)
+                .align_x(Alignment::Center),
+        )
+        .center(Length::Fill)
+        .into()
     }
 }

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -172,14 +172,10 @@ impl App {
         let version_label = text(format!("RabbiTTY v{}", env!("CARGO_PKG_VERSION")))
             .size(13)
             .color(Color::from_rgba(1.0, 1.0, 1.0, 0.4));
-        let new_tab_btn =
-            button_secondary("New Tab", palette).on_press(Message::OpenShellPicker);
+        let new_tab_btn = button_secondary("New Tab", palette).on_press(Message::OpenShellPicker);
 
-        let mut content: Vec<Element<Message>> = vec![
-            logo.into(),
-            version_label.into(),
-            new_tab_btn.into(),
-        ];
+        let mut content: Vec<Element<Message>> =
+            vec![logo.into(), version_label.into(), new_tab_btn.into()];
 
         if !self.session_history.entries.is_empty() {
             content.push(
@@ -198,7 +194,10 @@ impl App {
             content.push(
                 text("Recent Sessions")
                     .size(11)
-                    .color(Color { a: 0.5, ..palette.text_secondary })
+                    .color(Color {
+                        a: 0.5,
+                        ..palette.text_secondary
+                    })
                     .into(),
             );
 
@@ -211,31 +210,43 @@ impl App {
                 };
 
                 let label_col = column![
-                    text(name).size(13).color(Color { a: 0.9, ..palette.text }),
-                    text(kind_label).size(10).color(Color { a: 0.5, ..palette.text_secondary }),
+                    text(name).size(13).color(Color {
+                        a: 0.9,
+                        ..palette.text
+                    }),
+                    text(kind_label).size(10).color(Color {
+                        a: 0.5,
+                        ..palette.text_secondary
+                    }),
                 ]
                 .spacing(1);
 
                 content.push(
                     button(label_col)
-                        .style(move |_theme: &iced::Theme, status: iced::widget::button::Status| {
-                            let hovered = matches!(status, iced::widget::button::Status::Hovered);
-                            iced::widget::button::Style {
-                                background: Some(Background::Color(if hovered {
-                                    Color { a: 0.08, ..palette.text }
-                                } else {
-                                    Color::TRANSPARENT
-                                })),
-                                text_color: palette.text,
-                                border: Border {
-                                    radius: RADIUS_SMALL.into(),
-                                    width: 0.0,
-                                    color: Color::TRANSPARENT,
-                                },
-                                shadow: iced::Shadow::default(),
-                                snap: false,
-                            }
-                        })
+                        .style(
+                            move |_theme: &iced::Theme, status: iced::widget::button::Status| {
+                                let hovered =
+                                    matches!(status, iced::widget::button::Status::Hovered);
+                                iced::widget::button::Style {
+                                    background: Some(Background::Color(if hovered {
+                                        Color {
+                                            a: 0.08,
+                                            ..palette.text
+                                        }
+                                    } else {
+                                        Color::TRANSPARENT
+                                    })),
+                                    text_color: palette.text,
+                                    border: Border {
+                                        radius: RADIUS_SMALL.into(),
+                                        width: 0.0,
+                                        color: Color::TRANSPARENT,
+                                    },
+                                    shadow: iced::Shadow::default(),
+                                    snap: false,
+                                }
+                            },
+                        )
                         .padding([6, 10])
                         .width(Length::Fixed(240.0))
                         .on_press(Message::LaunchFromHistory(i))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,6 @@ pub mod gui;
 pub mod keychain;
 pub mod platform;
 pub mod session;
+pub mod session_history;
 pub mod ssh;
 pub mod terminal;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod gui;
 mod keychain;
 mod platform;
 mod session;
+mod session_history;
 mod ssh;
 mod terminal;
 

--- a/src/session_history.rs
+++ b/src/session_history.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_ENTRIES: usize = 10;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum SessionKind {
+    Default,
+    Shell { name: String, path: String },
+    Ssh { host: String, port: u16, user: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionHistoryEntry {
+    pub kind: SessionKind,
+    pub display_name: String,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionHistory {
+    pub entries: Vec<SessionHistoryEntry>,
+}
+
+impl SessionHistory {
+    pub fn load() -> Self {
+        let Some(path) = history_path() else {
+            return Self::default();
+        };
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self) {
+        let Some(path) = history_path() else { return };
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Ok(s) = toml::to_string_pretty(self) {
+            let _ = std::fs::write(&path, s);
+        }
+    }
+
+    pub fn record(&mut self, kind: SessionKind, display_name: String) {
+        self.entries.retain(|e| e.kind != kind);
+        self.entries.insert(
+            0,
+            SessionHistoryEntry {
+                kind,
+                display_name,
+                timestamp: SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            },
+        );
+        self.entries.truncate(MAX_ENTRIES);
+        self.save();
+    }
+}
+
+fn history_path() -> Option<PathBuf> {
+    Some(dirs::config_dir()?.join("rabbitty").join("session_history.toml"))
+}

--- a/src/session_history.rs
+++ b/src/session_history.rs
@@ -8,8 +8,15 @@ const MAX_ENTRIES: usize = 10;
 #[serde(tag = "type")]
 pub enum SessionKind {
     Default,
-    Shell { name: String, path: String },
-    Ssh { host: String, port: u16, user: String },
+    Shell {
+        name: String,
+        path: String,
+    },
+    Ssh {
+        host: String,
+        port: u16,
+        user: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -64,5 +71,9 @@ impl SessionHistory {
 }
 
 fn history_path() -> Option<PathBuf> {
-    Some(dirs::config_dir()?.join("rabbitty").join("session_history.toml"))
+    Some(
+        dirs::config_dir()?
+            .join("rabbitty")
+            .join("session_history.toml"),
+    )
 }


### PR DESCRIPTION
## Summary
- 탭이 없을 때 로비 화면에 최근 실행한 세션 목록 표시
- 클릭하면 해당 셸/SSH 세션 즉시 재시작
- `~/.config/rabbitty/session_history.toml`에 최근 10개 세션 저장
- Shell(Default/Named), SSH 세션 모두 지원