### PR TITLE
fix: 셸 피커 아이콘 fade out 애니메이션 미적용 수정

### DIFF
--- a/src/gui/app/view/shell_picker.rs
+++ b/src/gui/app/view/shell_picker.rs
@@ -59,11 +59,9 @@ impl PickerStyle {
         svg(shell_icon.handle)
             .width(Length::Fixed(16.0))
             .height(Length::Fixed(16.0))
+            .opacity(alpha)
             .style(move |_theme: &iced::Theme, _status| svg::Style {
-                color: Some(Color {
-                    a: alpha,
-                    ..icon_color
-                }),
+                color: Some(icon_color),
             })
             .into()
     }


### PR DESCRIPTION
## Summary
- iced SVG 위젯의 `color.a` 대신 `.opacity()` 메서드로 투명도 제어하도록 수정
- `color`의 alpha 채널은 틴트 색상에만 영향, 실제 렌더링 투명도는 `opacity` 필드가 제어

## Test plan
- [x] `cargo check` 통과
- [x] 셸 피커 열기/닫기 시 아이콘 fade in/out 확인