### PR TITLE
feat: 세션 복제 기능 추가

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,11 @@ pub const DEFAULT_SHORTCUT_FONT_SIZE_RESET: &str = "Command+0";
 #[cfg(not(target_os = "macos"))]
 pub const DEFAULT_SHORTCUT_FONT_SIZE_RESET: &str = "Ctrl+0";
 
+#[cfg(target_os = "macos")]
+pub const DEFAULT_SHORTCUT_DUPLICATE_TAB: &str = "Command+D";
+#[cfg(not(target_os = "macos"))]
+pub const DEFAULT_SHORTCUT_DUPLICATE_TAB: &str = "Ctrl+Shift+D";
+
 pub const DEFAULT_TERMINAL_FONT_SIZE: f32 = 14.0;
 pub const DEFAULT_TERMINAL_PADDING_X: f32 = 4.0;
 pub const DEFAULT_TERMINAL_PADDING_Y: f32 = 4.0;
@@ -146,6 +151,7 @@ pub struct ShortcutsConfig {
     pub font_size_increase: String,
     pub font_size_decrease: String,
     pub font_size_reset: String,
+    pub duplicate_tab: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -209,6 +215,7 @@ struct ShortcutsFileConfig {
     font_size_increase: Option<String>,
     font_size_decrease: Option<String>,
     font_size_reset: Option<String>,
+    duplicate_tab: Option<String>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -236,6 +243,7 @@ pub struct AppConfigUpdates {
     pub shortcut_font_size_increase: Option<String>,
     pub shortcut_font_size_decrease: Option<String>,
     pub shortcut_font_size_reset: Option<String>,
+    pub shortcut_duplicate_tab: Option<String>,
 }
 
 impl Default for AppConfig {
@@ -274,6 +282,7 @@ impl Default for AppConfig {
                 font_size_increase: DEFAULT_SHORTCUT_FONT_SIZE_INCREASE.to_string(),
                 font_size_decrease: DEFAULT_SHORTCUT_FONT_SIZE_DECREASE.to_string(),
                 font_size_reset: DEFAULT_SHORTCUT_FONT_SIZE_RESET.to_string(),
+                duplicate_tab: DEFAULT_SHORTCUT_DUPLICATE_TAB.to_string(),
             },
             ssh_profiles: vec![],
         }
@@ -378,6 +387,9 @@ impl AppConfig {
         if let Some(value) = updates.shortcut_font_size_reset {
             self.shortcuts.font_size_reset =
                 sanitize_shortcut(&value, &self.shortcuts.font_size_reset);
+        }
+        if let Some(value) = updates.shortcut_duplicate_tab {
+            self.shortcuts.duplicate_tab = sanitize_shortcut(&value, &self.shortcuts.duplicate_tab);
         }
     }
 
@@ -511,6 +523,10 @@ impl AppConfig {
             if let Some(value) = shortcuts.font_size_reset.as_deref() {
                 self.shortcuts.font_size_reset =
                     sanitize_shortcut(value, &self.shortcuts.font_size_reset);
+            }
+            if let Some(value) = shortcuts.duplicate_tab.as_deref() {
+                self.shortcuts.duplicate_tab =
+                    sanitize_shortcut(value, &self.shortcuts.duplicate_tab);
             }
         }
 
@@ -782,6 +798,7 @@ impl From<&AppConfig> for FileConfig {
                 font_size_increase: Some(config.shortcuts.font_size_increase.clone()),
                 font_size_decrease: Some(config.shortcuts.font_size_decrease.clone()),
                 font_size_reset: Some(config.shortcuts.font_size_reset.clone()),
+                duplicate_tab: Some(config.shortcuts.duplicate_tab.clone()),
             }),
             ssh_profiles: if config.ssh_profiles.is_empty() {
                 None
@@ -832,7 +849,7 @@ fn ensure_config_file(path: &Path) -> std::io::Result<()> {
 
 fn default_config_toml() -> String {
     format!(
-        "[ui]\nwindow_width = {width}\nwindow_height = {height}\n\n[terminal]\nfont_selection = \"\"\nfont_size = {font_size:.1}\npadding_x = {padding_x:.1}\npadding_y = {padding_y:.1}\n\n[theme]\ncolor_scheme = \"Catppuccin Mocha\"\nforeground = \"#{fg:02x}{fg_g:02x}{fg_b:02x}\"\nbackground = \"#{bg:02x}{bg_g:02x}{bg_b:02x}\"\ncursor = \"#{cur:02x}{cur_g:02x}{cur_b:02x}\"\nbackground_opacity = {opacity:.2}\nblur_enabled = {blur_enabled}\nmacos_blur_radius = {macos_blur_radius}\n\n[shortcuts]\nnew_tab = \"{shortcut_new_tab}\"\nclose_tab = \"{shortcut_close_tab}\"\nopen_settings = \"{shortcut_open_settings}\"\nnext_tab = \"{shortcut_next_tab}\"\nprev_tab = \"{shortcut_prev_tab}\"\nquit = \"{shortcut_quit}\"\nfont_size_increase = \"{shortcut_font_size_increase}\"\nfont_size_decrease = \"{shortcut_font_size_decrease}\"\nfont_size_reset = \"{shortcut_font_size_reset}\"\n",
+        "[ui]\nwindow_width = {width}\nwindow_height = {height}\n\n[terminal]\nfont_selection = \"\"\nfont_size = {font_size:.1}\npadding_x = {padding_x:.1}\npadding_y = {padding_y:.1}\n\n[theme]\ncolor_scheme = \"Catppuccin Mocha\"\nforeground = \"#{fg:02x}{fg_g:02x}{fg_b:02x}\"\nbackground = \"#{bg:02x}{bg_g:02x}{bg_b:02x}\"\ncursor = \"#{cur:02x}{cur_g:02x}{cur_b:02x}\"\nbackground_opacity = {opacity:.2}\nblur_enabled = {blur_enabled}\nmacos_blur_radius = {macos_blur_radius}\n\n[shortcuts]\nnew_tab = \"{shortcut_new_tab}\"\nclose_tab = \"{shortcut_close_tab}\"\nopen_settings = \"{shortcut_open_settings}\"\nnext_tab = \"{shortcut_next_tab}\"\nprev_tab = \"{shortcut_prev_tab}\"\nquit = \"{shortcut_quit}\"\nfont_size_increase = \"{shortcut_font_size_increase}\"\nfont_size_decrease = \"{shortcut_font_size_decrease}\"\nfont_size_reset = \"{shortcut_font_size_reset}\"\nduplicate_tab = \"{shortcut_duplicate_tab}\"\n",
         width = DEFAULT_WINDOW_WIDTH as u32,
         height = DEFAULT_WINDOW_HEIGHT as u32,
         font_size = DEFAULT_TERMINAL_FONT_SIZE,
@@ -858,7 +875,8 @@ fn default_config_toml() -> String {
         shortcut_quit = DEFAULT_SHORTCUT_QUIT,
         shortcut_font_size_increase = DEFAULT_SHORTCUT_FONT_SIZE_INCREASE,
         shortcut_font_size_decrease = DEFAULT_SHORTCUT_FONT_SIZE_DECREASE,
-        shortcut_font_size_reset = DEFAULT_SHORTCUT_FONT_SIZE_RESET
+        shortcut_font_size_reset = DEFAULT_SHORTCUT_FONT_SIZE_RESET,
+        shortcut_duplicate_tab = DEFAULT_SHORTCUT_DUPLICATE_TAB
     )
 }
 

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -47,6 +47,7 @@ pub enum Message {
     SaveSshProfileModal,
     CreateSshTab(usize),
     LaunchFromHistory(usize),
+    DuplicateTab,
     #[cfg(target_os = "macos")]
     ConfirmRestartForBlur,
     #[cfg(target_os = "macos")]

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -48,6 +48,9 @@ pub enum Message {
     CreateSshTab(usize),
     LaunchFromHistory(usize),
     DuplicateTab,
+    ShowTabContextMenu(usize),
+    CloseTabContextMenu,
+    CursorMoved(iced::Point),
     #[cfg(target_os = "macos")]
     ConfirmRestartForBlur,
     #[cfg(target_os = "macos")]
@@ -131,6 +134,8 @@ pub struct App {
     pub(super) ime_preedit: Option<(String, Option<std::ops::Range<usize>>)>,
     pub(super) session_history: SessionHistory,
     pub(super) window_style_applied: bool,
+    pub(super) tab_context_menu: Option<usize>,
+    pub(super) cursor_position: iced::Point,
     #[cfg(target_os = "macos")]
     pub(super) show_restart_confirm: bool,
     #[cfg(target_os = "macos")]
@@ -176,6 +181,8 @@ impl App {
             resize_debounce_spawned_seq: 0,
             session_history: SessionHistory::load(),
             palette,
+            tab_context_menu: None,
+            cursor_position: iced::Point::ORIGIN,
             ime_active: false,
             ime_preedit: None,
             shell_picker_anim: Animation::new(false)

--- a/src/gui/app/shortcuts.rs
+++ b/src/gui/app/shortcuts.rs
@@ -73,6 +73,7 @@ pub(super) enum ShortcutAction {
     FontSizeIncrease,
     FontSizeDecrease,
     FontSizeReset,
+    DuplicateTab,
 }
 
 impl ShortcutAction {
@@ -107,6 +108,9 @@ impl ShortcutAction {
         }
         if shortcut_matches(&shortcuts.font_size_reset, key, modifiers) {
             return Some(Self::FontSizeReset);
+        }
+        if shortcut_matches(&shortcuts.duplicate_tab, key, modifiers) {
+            return Some(Self::DuplicateTab);
         }
         None
     }

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -126,6 +126,12 @@ impl App {
                     return self.create_tab(shell);
                 }
             }
+            Message::DuplicateTab => {
+                if let Some(tab) = self.tabs.get(self.active_tab) {
+                    let shell = tab.shell.clone();
+                    return self.create_tab(shell);
+                }
+            }
 
             // ── Settings ────────────────────────────────────────────
             Message::AddSshProfile => {

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -127,10 +127,21 @@ impl App {
                 }
             }
             Message::DuplicateTab => {
-                if let Some(tab) = self.tabs.get(self.active_tab) {
+                let index = self.tab_context_menu.unwrap_or(self.active_tab);
+                self.tab_context_menu = None;
+                if let Some(tab) = self.tabs.get(index) {
                     let shell = tab.shell.clone();
                     return self.create_tab(shell);
                 }
+            }
+            Message::ShowTabContextMenu(index) => {
+                self.tab_context_menu = Some(index);
+            }
+            Message::CloseTabContextMenu => {
+                self.tab_context_menu = None;
+            }
+            Message::CursorMoved(point) => {
+                self.cursor_position = point;
             }
 
             // ── Settings ────────────────────────────────────────────

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -100,6 +100,7 @@ impl App {
                 self.drag_target = None;
             }
             Message::CloseTab(index) => {
+                self.tab_context_menu = None;
                 self.handle_close_tab(index);
             }
             Message::OpenShellPicker => {
@@ -141,7 +142,9 @@ impl App {
                 self.tab_context_menu = None;
             }
             Message::CursorMoved(point) => {
-                self.cursor_position = point;
+                if self.tab_context_menu.is_none() {
+                    self.cursor_position = point;
+                }
             }
 
             // ── Settings ────────────────────────────────────────────

--- a/src/gui/app/update/tab.rs
+++ b/src/gui/app/update/tab.rs
@@ -134,6 +134,7 @@ impl App {
             ShortcutAction::FontSizeReset => {
                 Some(self.set_font_size(crate::config::DEFAULT_TERMINAL_FONT_SIZE))
             }
+            ShortcutAction::DuplicateTab => Some(self.update(Message::DuplicateTab)),
         }
     }
 

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -278,11 +278,11 @@ impl App {
             base_layout,
             vec![
                 ContextMenuItem {
-                    label: "복제",
+                    label: "Duplicate",
                     message: Message::DuplicateTab,
                 },
                 ContextMenuItem {
-                    label: "닫기",
+                    label: "Close",
                     message: Message::CloseTab(tab_index),
                 },
             ],

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -7,6 +7,7 @@ mod shell_picker;
 pub(in crate::gui) use dialog::{DialogButton, confirm_dialog};
 
 use super::{App, Message, SETTINGS_TAB_INDEX};
+use crate::gui::components::context_menu::{ContextMenuItem, context_menu};
 use crate::gui::components::ime_wrapper::ImeEnabled;
 use crate::gui::components::{button_secondary, panel, tab_bar};
 use crate::gui::render::TerminalProgram;
@@ -95,6 +96,10 @@ impl App {
 
         if self.show_shell_picker {
             return self.view_shell_picker(base_layout);
+        }
+
+        if let Some(tab_index) = self.tab_context_menu {
+            return self.view_tab_context_menu(base_layout, tab_index);
         }
 
         base_layout.into()
@@ -262,5 +267,28 @@ impl App {
         )
         .center(Length::Fill)
         .into()
+    }
+
+    fn view_tab_context_menu<'a>(
+        &'a self,
+        base_layout: impl Into<Element<'a, Message>>,
+        tab_index: usize,
+    ) -> Element<'a, Message> {
+        context_menu(
+            base_layout,
+            vec![
+                ContextMenuItem {
+                    label: "복제",
+                    message: Message::DuplicateTab,
+                },
+                ContextMenuItem {
+                    label: "닫기",
+                    message: Message::CloseTab(tab_index),
+                },
+            ],
+            self.cursor_position,
+            Message::CloseTabContextMenu,
+            self.palette,
+        )
     }
 }

--- a/src/gui/components/context_menu.rs
+++ b/src/gui/components/context_menu.rs
@@ -1,0 +1,92 @@
+use crate::gui::app::Message;
+use crate::gui::theme::{Palette, RADIUS_SMALL};
+use iced::widget::{button, column, container, mouse_area, stack, text};
+use iced::{Background, Border, Color, Element, Length, Padding};
+
+pub struct ContextMenuItem {
+    pub label: &'static str,
+    pub message: Message,
+}
+
+pub fn context_menu<'a>(
+    base: impl Into<Element<'a, Message>>,
+    items: Vec<ContextMenuItem>,
+    position: iced::Point,
+    on_dismiss: Message,
+    palette: Palette,
+) -> Element<'a, Message> {
+    let menu_items: Vec<Element<Message>> = items
+        .into_iter()
+        .map(|item| {
+            button(text(item.label).size(13))
+                .on_press(item.message)
+                .padding([7, 14])
+                .width(Length::Fill)
+                .style(
+                    move |_theme: &iced::Theme, status: button::Status| button::Style {
+                        background: Some(Background::Color(
+                            if matches!(status, button::Status::Hovered) {
+                                Color {
+                                    a: 0.1,
+                                    ..palette.text
+                                }
+                            } else {
+                                Color::TRANSPARENT
+                            },
+                        )),
+                        text_color: palette.text,
+                        border: Border {
+                            radius: RADIUS_SMALL.into(),
+                            width: 0.0,
+                            color: Color::TRANSPARENT,
+                        },
+                        shadow: iced::Shadow::default(),
+                        snap: false,
+                    },
+                )
+                .into()
+        })
+        .collect();
+
+    let menu = container(column(menu_items).padding([4, 4]))
+        .width(Length::Fixed(140.0))
+        .style(move |_theme: &iced::Theme| container::Style {
+            background: Some(Background::Color(Color {
+                a: 0.97,
+                ..palette.surface
+            })),
+            border: Border {
+                radius: RADIUS_SMALL.into(),
+                width: 1.0,
+                color: Color {
+                    a: 0.15,
+                    ..palette.text
+                },
+            },
+            shadow: iced::Shadow {
+                color: Color {
+                    a: 0.3,
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                },
+                offset: iced::Vector::new(0.0, 4.0),
+                blur_radius: 12.0,
+            },
+            ..Default::default()
+        });
+
+    let backdrop = mouse_area(container(text("")).width(Length::Fill).height(Length::Fill))
+        .on_press(on_dismiss.clone())
+        .on_right_press(on_dismiss);
+
+    let positioned = container(menu)
+        .padding(Padding::new(0.0).top(position.y).left(position.x))
+        .width(Length::Fill)
+        .height(Length::Fill);
+
+    stack![base.into(), backdrop, positioned]
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into()
+}

--- a/src/gui/components/mod.rs
+++ b/src/gui/components/mod.rs
@@ -1,5 +1,6 @@
 pub mod button;
 pub mod container;
+pub mod context_menu;
 pub mod ime_wrapper;
 pub mod tab_bar;
 

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -44,6 +44,8 @@ pub fn tab_bar<'a>(
         let tab_item = mouse_area(tab_item)
             .on_press(Message::TabSelected(index))
             .on_enter(Message::TabDragHover(index))
+            .on_right_press(Message::ShowTabContextMenu(index))
+            .on_move(move |p| Message::CursorMoved(p))
             .into();
         tab_elements.push(tab_item);
     }

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -41,13 +41,16 @@ pub fn tab_bar<'a>(
         }
 
         let tab_item = browser_tab(title, index, is_active, tab_alpha, palette);
-        let tab_item = mouse_area(tab_item)
+        let is_terminal_tab = index != crate::gui::app::SETTINGS_TAB_INDEX;
+        let mut tab_item = mouse_area(tab_item)
             .on_press(Message::TabSelected(index))
-            .on_enter(Message::TabDragHover(index))
-            .on_right_press(Message::ShowTabContextMenu(index))
-            .on_move(move |p| Message::CursorMoved(p))
-            .into();
-        tab_elements.push(tab_item);
+            .on_enter(Message::TabDragHover(index));
+        if is_terminal_tab {
+            tab_item = tab_item
+                .on_right_press(Message::ShowTabContextMenu(index))
+                .on_move(Message::CursorMoved);
+        }
+        tab_elements.push(tab_item.into());
     }
 
     let icon_style = move |_theme: &Theme, status: button::Status| button::Style {


### PR DESCRIPTION
## Summary
- 현재 활성 탭과 동일한 셸/SSH 설정으로 새 탭을 여는 복제 기능 추가
- `Message::DuplicateTab`: 활성 탭의 `shell.clone()`으로 `create_tab` 호출
- `ShortcutAction::DuplicateTab` 및 단축키 바인딩 추가
- 기본 단축키: macOS `Command+D` / 기타 `Ctrl+Shift+D`
- `config.toml`의 `duplicate_tab` 키로 커스터마이징 가능

## Test plan
- [x] `cargo test` 41개 전체 통과
- [x] `cargo check` / `cargo clippy` 경고 없음
- [x] `cargo fmt` 적용

Closes #102