### PR TITLE
feat: add language picker in Settings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ fn main() {
     println!("cargo:rerun-if-changed=locales/");
 
     let locales_dir = Path::new("locales");
-    let mut locales: Vec<(String, HashMap<String, String>)> = Vec::new();
+    let mut locales: Vec<(String, String, HashMap<String, String>)> = Vec::new();
 
     if let Ok(entries) = std::fs::read_dir(locales_dir) {
         let mut paths: Vec<_> = entries
@@ -18,8 +18,10 @@ fn main() {
             let path = entry.path();
             let locale = path.file_stem().unwrap().to_str().unwrap().to_string();
             let src = std::fs::read_to_string(&path).unwrap();
-            let map = parse_toml(&src);
-            locales.push((locale, map));
+            let mut map = parse_toml(&src);
+            let native_label = map.remove("meta.name").unwrap_or_else(|| locale.clone());
+            map.retain(|k, _| !k.starts_with("meta."));
+            locales.push((locale, native_label, map));
         }
     }
 
@@ -27,10 +29,11 @@ fn main() {
     let out_path = Path::new(&out_dir).join("translations.rs");
 
     let mut code = String::new();
+
     code.push_str("fn get_translation(locale: &str, key: &str) -> Option<&'static str> {\n");
     code.push_str("    match locale {\n");
 
-    for (locale, map) in &locales {
+    for (locale, _label, map) in &locales {
         if locale == "en" {
             continue;
         }
@@ -45,7 +48,7 @@ fn main() {
     }
 
     code.push_str("        _ => match key {\n");
-    if let Some((_, en_map)) = locales.iter().find(|(l, _)| l == "en") {
+    if let Some((_, _, en_map)) = locales.iter().find(|(l, _, _)| l == "en") {
         let mut keys: Vec<_> = en_map.keys().collect();
         keys.sort();
         for k in keys {
@@ -56,6 +59,15 @@ fn main() {
     code.push_str("        },\n");
     code.push_str("    }\n");
     code.push_str("}\n");
+
+    code.push_str("\npub const AVAILABLE_LOCALES: &[LocaleInfo] = &[\n");
+    for (locale, label, _map) in &locales {
+        code.push_str(&format!(
+            "    LocaleInfo {{ tag: {:?}, native_label: {:?} }},\n",
+            locale, label
+        ));
+    }
+    code.push_str("];\n");
 
     std::fs::write(out_path, code).unwrap();
 }

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -1,3 +1,6 @@
+[meta]
+name = "English"
+
 [shell_picker]
 title = "Start New Session"
 ssh = "SSH"
@@ -16,3 +19,19 @@ recent_sessions = "Recent Sessions"
 default_shell = "Default Shell"
 shell = "Shell"
 ssh = "SSH"
+
+[settings.categories]
+ui = "UI"
+terminal = "Terminal"
+theme = "Theme"
+shortcuts = "Shortcuts"
+ssh = "SSH"
+
+[settings.ui]
+window_section = "Window"
+width = "Width"
+height = "Height"
+
+[settings.language]
+section_title = "Language"
+auto = "Auto"

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -1,3 +1,6 @@
+[meta]
+name = "한국어"
+
 [shell_picker]
 title = "새 세션 시작"
 ssh = "SSH"
@@ -16,3 +19,19 @@ recent_sessions = "최근 세션"
 default_shell = "기본 셸"
 shell = "셸"
 ssh = "SSH"
+
+[settings.categories]
+ui = "UI"
+terminal = "터미널"
+theme = "테마"
+shortcuts = "단축키"
+ssh = "SSH"
+
+[settings.ui]
+window_section = "창"
+width = "너비"
+height = "높이"
+
+[settings.language]
+section_title = "언어"
+auto = "자동"

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,8 @@ pub struct AppConfig {
 pub struct UiConfig {
     pub window_width: f32,
     pub window_height: f32,
+    /// `None` = follow `LANG` env; otherwise a tag from `AVAILABLE_LOCALES`.
+    pub language: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -178,6 +180,7 @@ struct FileConfig {
 struct UiFileConfig {
     window_width: Option<f32>,
     window_height: Option<f32>,
+    language: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -222,6 +225,8 @@ struct ShortcutsFileConfig {
 pub struct AppConfigUpdates {
     pub window_width: Option<f32>,
     pub window_height: Option<f32>,
+    /// `None` = no change; `Some("auto"|"")` = clear; `Some("<tag>")` = set.
+    pub language: Option<String>,
     pub terminal_font_selection: Option<String>,
     pub terminal_font_size: Option<f32>,
     pub terminal_padding_x: Option<f32>,
@@ -253,6 +258,7 @@ impl Default for AppConfig {
             ui: UiConfig {
                 window_width: DEFAULT_WINDOW_WIDTH,
                 window_height: DEFAULT_WINDOW_HEIGHT,
+                language: None,
             },
             terminal: TerminalConfig {
                 cell_width,
@@ -309,6 +315,9 @@ impl AppConfig {
         }
         if let Some(height) = updates.window_height {
             self.ui.window_height = sanitize_positive(height, self.ui.window_height);
+        }
+        if let Some(lang) = updates.language.as_deref() {
+            self.ui.language = sanitize_language(lang);
         }
         let old_font = self.terminal.font_selection.clone();
         if let Some(selection) = updates.terminal_font_selection {
@@ -414,6 +423,9 @@ impl AppConfig {
             }
             if let Some(height) = ui.window_height {
                 self.ui.window_height = sanitize_positive(height, self.ui.window_height);
+            }
+            if let Some(lang) = ui.language.as_deref() {
+                self.ui.language = sanitize_language(lang);
             }
         }
 
@@ -611,6 +623,15 @@ fn sanitize_padding(value: f32) -> f32 {
     }
 }
 
+fn sanitize_language(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if crate::i18n::is_known_locale(trimmed) {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
 fn sanitize_terminal_font_selection(value: &str) -> Option<String> {
     let selection = value.trim();
     if selection.is_empty() {
@@ -747,6 +768,7 @@ impl From<&AppConfig> for FileConfig {
             ui: Some(UiFileConfig {
                 window_width: Some(config.ui.window_width),
                 window_height: Some(config.ui.window_height),
+                language: config.ui.language.clone(),
             }),
             terminal: Some(TerminalFileConfig {
                 cell_width: None,

--- a/src/gui/app/update/settings.rs
+++ b/src/gui/app/update/settings.rs
@@ -35,6 +35,7 @@ impl App {
 
     pub(super) fn apply_updates_to_runtime(&mut self, updates: AppConfigUpdates) -> Task<Message> {
         self.config.apply_updates(updates);
+        crate::i18n::set_locale(self.config.ui.language.as_deref());
         self.palette = crate::gui::theme::Palette::from_theme(&self.config.theme);
         self.settings_draft = SettingsDraft::from_config(&self.config);
 

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -26,6 +26,7 @@ impl fmt::Display for TerminalFontOption {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingsField {
+    UiLanguage,
     UiWindowWidth,
     UiWindowHeight,
     TerminalFontSelection,
@@ -80,11 +81,11 @@ impl SettingsCategory {
 
     pub fn label(self) -> &'static str {
         match self {
-            Self::Ui => "UI",
-            Self::Terminal => "Terminal",
-            Self::Theme => "Theme",
-            Self::Shortcuts => "Shortcuts",
-            Self::Ssh => "SSH",
+            Self::Ui => crate::t!("settings.categories.ui"),
+            Self::Terminal => crate::t!("settings.categories.terminal"),
+            Self::Theme => crate::t!("settings.categories.theme"),
+            Self::Shortcuts => crate::t!("settings.categories.shortcuts"),
+            Self::Ssh => crate::t!("settings.categories.ssh"),
         }
     }
 
@@ -207,6 +208,7 @@ impl SshProfileDraft {
 
 #[derive(Debug, Clone)]
 pub struct SettingsDraft {
+    pub language: String,
     pub window_width: String,
     pub window_height: String,
     pub terminal_font_selection: String,
@@ -237,6 +239,11 @@ pub struct SettingsDraft {
 impl SettingsDraft {
     pub fn from_config(config: &AppConfig) -> Self {
         Self {
+            language: config
+                .ui
+                .language
+                .clone()
+                .unwrap_or_else(|| "auto".to_string()),
             window_width: format!("{:.0}", config.ui.window_width),
             window_height: format!("{:.0}", config.ui.window_height),
             terminal_font_selection: config.terminal.font_selection.clone().unwrap_or_default(),
@@ -417,6 +424,7 @@ impl SettingsDraft {
 
     pub fn update(&mut self, field: SettingsField, value: String) {
         match field {
+            SettingsField::UiLanguage => self.language = value,
             SettingsField::UiWindowWidth => self.window_width = value,
             SettingsField::UiWindowHeight => self.window_height = value,
             SettingsField::TerminalFontSelection => self.terminal_font_selection = value,
@@ -454,6 +462,7 @@ impl SettingsDraft {
         let ansi_colors = crate::terminal::theme::find_preset(&self.color_scheme).map(|p| p.ansi);
 
         let mut updates = AppConfigUpdates {
+            language: Some(self.language.clone()),
             window_width: parse_f32(&self.window_width),
             window_height: parse_f32(&self.window_height),
             terminal_font_selection: Some(self.terminal_font_selection.clone()),

--- a/src/gui/settings/ui.rs
+++ b/src/gui/settings/ui.rs
@@ -1,27 +1,34 @@
 use crate::config::AppConfig;
 use crate::gui::app::Message;
 use crate::gui::settings::{SettingsDraft, SettingsField, input_row_with_suffix, section};
-use crate::gui::theme::{Palette, SPACING_NORMAL};
-use iced::widget::column;
-use iced::{Element, Length};
+use crate::gui::theme::{Palette, RADIUS_SMALL, SPACING_NORMAL};
+use crate::i18n::AVAILABLE_LOCALES;
+use iced::widget::{button, column, row, text};
+use iced::{Background, Border, Color, Element, Length};
 
 pub fn view<'a>(
     _config: &'a AppConfig,
     draft: &'a SettingsDraft,
     palette: Palette,
 ) -> Element<'a, Message> {
+    let language_section = section(
+        t!("settings.language.section_title"),
+        language_picker(&draft.language, palette),
+        palette,
+    );
+
     let window_section = section(
-        "Window",
+        t!("settings.ui.window_section"),
         column(vec![
             input_row_with_suffix(
-                "Width",
+                t!("settings.ui.width"),
                 &draft.window_width,
                 SettingsField::UiWindowWidth,
                 "px",
                 palette,
             ),
             input_row_with_suffix(
-                "Height",
+                t!("settings.ui.height"),
                 &draft.window_height,
                 SettingsField::UiWindowHeight,
                 "px",
@@ -34,8 +41,72 @@ pub fn view<'a>(
         palette,
     );
 
-    column(vec![window_section])
+    column(vec![language_section, window_section])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into()
+}
+
+fn language_picker<'a>(current: &'a str, palette: Palette) -> Element<'a, Message> {
+    let mut buttons: Vec<Element<'a, Message>> = Vec::with_capacity(AVAILABLE_LOCALES.len() + 1);
+    buttons.push(language_button(
+        "auto",
+        t!("settings.language.auto"),
+        current,
+        palette,
+    ));
+    for locale in AVAILABLE_LOCALES {
+        buttons.push(language_button(
+            locale.tag,
+            locale.native_label,
+            current,
+            palette,
+        ));
+    }
+    row(buttons).spacing(8).width(Length::Fill).into()
+}
+
+fn language_button<'a>(
+    tag: &'static str,
+    label: &'static str,
+    current: &str,
+    palette: Palette,
+) -> Element<'a, Message> {
+    let is_selected = current == tag;
+    let accent = palette.accent;
+    let text_color = palette.text;
+    let surface = palette.surface;
+
+    button(
+        text(label)
+            .size(13)
+            .color(if is_selected { accent } else { text_color }),
+    )
+    .on_press(Message::SettingsInputChanged(
+        SettingsField::UiLanguage,
+        tag.to_string(),
+    ))
+    .padding([6, 14])
+    .style(move |_theme: &iced::Theme, _status| button::Style {
+        background: Some(Background::Color(Color {
+            a: if is_selected { 0.25 } else { 0.12 },
+            ..surface
+        })),
+        text_color: if is_selected { accent } else { text_color },
+        border: Border {
+            radius: RADIUS_SMALL.into(),
+            width: if is_selected { 1.5 } else { 1.0 },
+            color: if is_selected {
+                accent
+            } else {
+                Color {
+                    a: 0.15,
+                    ..text_color
+                }
+            },
+        },
+        shadow: Default::default(),
+        snap: true,
+    })
+    .into()
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -7,19 +7,62 @@ macro_rules! t {
 
 include!(concat!(env!("OUT_DIR"), "/translations.rs"));
 
-fn detect_locale() -> &'static str {
+use std::sync::{OnceLock, RwLock};
+
+#[derive(Debug, Clone, Copy)]
+pub struct LocaleInfo {
+    pub tag: &'static str,
+    pub native_label: &'static str,
+}
+
+pub fn is_known_locale(tag: &str) -> bool {
+    AVAILABLE_LOCALES.iter().any(|l| l.tag == tag)
+}
+
+static CURRENT_LOCALE: RwLock<&'static str> = RwLock::new("en");
+static INITIALIZED: OnceLock<()> = OnceLock::new();
+
+fn fallback_locale() -> &'static str {
+    AVAILABLE_LOCALES.first().map(|l| l.tag).unwrap_or("en")
+}
+
+fn detect_locale_from_env() -> &'static str {
     let lang = std::env::var("LANG")
         .or_else(|_| std::env::var("LC_ALL"))
         .or_else(|_| std::env::var("LC_MESSAGES"))
         .unwrap_or_default()
         .to_lowercase();
 
-    if lang.starts_with("ko") { "ko" } else { "en" }
+    AVAILABLE_LOCALES
+        .iter()
+        .find(|l| lang.starts_with(l.tag))
+        .map(|l| l.tag)
+        .unwrap_or_else(fallback_locale)
+}
+
+fn resolve(locale: Option<&str>) -> &'static str {
+    let candidate = locale.map(str::trim).unwrap_or("");
+    if candidate.is_empty() || candidate == "auto" {
+        return detect_locale_from_env();
+    }
+    AVAILABLE_LOCALES
+        .iter()
+        .find(|l| l.tag == candidate)
+        .map(|l| l.tag)
+        .unwrap_or_else(detect_locale_from_env)
+}
+
+pub fn set_locale(locale: Option<&str>) {
+    let resolved = resolve(locale);
+    *CURRENT_LOCALE.write().expect("i18n locale lock poisoned") = resolved;
+    let _ = INITIALIZED.set(());
 }
 
 pub fn t(key: &'static str) -> &'static str {
-    static LOCALE: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
-    let locale = LOCALE.get_or_init(detect_locale);
+    if INITIALIZED.get().is_none() {
+        set_locale(None);
+    }
+    let locale = *CURRENT_LOCALE.read().expect("i18n locale lock poisoned");
     get_translation(locale, key).unwrap_or(key)
 }
 
@@ -46,5 +89,13 @@ mod tests {
     #[test]
     fn unknown_key_returns_none() {
         assert_eq!(get_translation("en", "nonexistent.key"), None);
+    }
+
+    #[test]
+    fn set_locale_switches_active_translation() {
+        set_locale(Some("ko"));
+        assert_eq!(t("shell_picker.title"), "새 세션 시작");
+        set_locale(Some("en"));
+        assert_eq!(t("shell_picker.title"), "Start New Session");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ const DEJAVU_SANS: &[u8] = include_bytes!("../fonts/DejaVuSans.ttf");
 
 fn main() -> iced::Result {
     let app_config = AppConfig::load();
+    i18n::set_locale(app_config.ui.language.as_deref());
     let boot_config = app_config.clone();
 
     iced::application(


### PR DESCRIPTION
Closes #106.

Adds a language picker in Settings (Auto / English / 한국어). Live switch on Apply, no restart. New locales auto-discovered from `locales/*.toml`.