### PR TITLE
fix: cache SSH passwords in-process

### DIFF
--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -3,7 +3,7 @@ mod tab;
 mod terminal;
 
 use super::{App, Message, SETTINGS_TAB_INDEX};
-use crate::gui::settings::{SettingsCategory, SettingsDraft, SettingsField};
+use crate::gui::settings::{SettingsDraft, SettingsField};
 use crate::gui::tab::ShellKind;
 use iced::keyboard::{Key, key::Named};
 use iced::time::Instant;
@@ -28,8 +28,6 @@ impl App {
     }
 
     fn save_ssh_profiles(&mut self) {
-        self.settings_draft
-            .load_ssh_passwords_from_keychain(&self.config.ssh_profiles);
         if let Err(err) = self
             .settings_draft
             .apply_ssh_profiles_to(&mut self.config.ssh_profiles)
@@ -38,19 +36,9 @@ impl App {
             return;
         }
 
-        for profile in &self.config.ssh_profiles {
-            if let Some(ref pw) = profile.password {
-                crate::keychain::set_password(&profile.host, &profile.user, pw);
-            } else {
-                crate::keychain::delete_password(&profile.host, &profile.user);
-            }
-        }
-
         match self.config.save() {
             Ok(()) => {
                 self.settings_draft = SettingsDraft::from_config(&self.config);
-                self.settings_draft
-                    .load_ssh_passwords_from_keychain(&self.config.ssh_profiles);
                 self.settings_draft.set_ssh_profiles_saved();
             }
             Err(err) => {
@@ -187,17 +175,24 @@ impl App {
                 self.settings_draft.close_ssh_profile_modal();
             }
             Message::SaveSshProfileModal => match self.settings_draft.save_ssh_profile_modal() {
-                Ok(()) => self.save_ssh_profiles(),
+                Ok(Some(profile)) => {
+                    match profile.password.as_deref() {
+                        Some(pw) => {
+                            crate::keychain::set_password(&profile.host, &profile.user, pw);
+                        }
+                        None => {
+                            crate::keychain::delete_password(&profile.host, &profile.user);
+                        }
+                    }
+                    self.save_ssh_profiles();
+                }
+                Ok(None) => {}
                 Err(err) => eprintln!("Failed to update SSH profile draft: {err}"),
             },
             Message::OpenSettingsTab => {
                 self.settings_open = true;
                 self.active_tab = SETTINGS_TAB_INDEX;
                 self.settings_draft = SettingsDraft::from_config(&self.config);
-                if matches!(self.settings_category, SettingsCategory::Ssh) {
-                    self.settings_draft
-                        .load_ssh_passwords_from_keychain(&self.config.ssh_profiles);
-                }
             }
             Message::SelectSettingsCategory(category) => {
                 self.settings_category = category;
@@ -205,10 +200,6 @@ impl App {
                     self.settings_open = true;
                     self.active_tab = SETTINGS_TAB_INDEX;
                     self.settings_draft = SettingsDraft::from_config(&self.config);
-                }
-                if matches!(category, SettingsCategory::Ssh) {
-                    self.settings_draft
-                        .load_ssh_passwords_from_keychain(&self.config.ssh_profiles);
                 }
             }
             Message::SettingsInputChanged(field, value) => {

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -276,18 +276,6 @@ impl SettingsDraft {
         }
     }
 
-    /// Load passwords from OS keychain into SSH profile drafts.
-    /// Call this only when the user opens SSH settings, not at app startup.
-    pub fn load_ssh_passwords_from_keychain(&mut self, profiles: &[SshProfile]) {
-        for (draft, profile) in self.ssh_profiles.iter_mut().zip(profiles.iter()) {
-            if draft.password.is_empty()
-                && let Some(pw) = crate::keychain::get_password(&profile.host, &profile.user)
-            {
-                draft.password = pw;
-            }
-        }
-    }
-
     #[cfg(test)]
     pub fn update_ssh_profile(&mut self, index: usize, field: SshProfileField, value: String) {
         self.ssh_profiles_error = None;
@@ -334,7 +322,14 @@ impl SettingsDraft {
         if let Some(profile) = self.ssh_profiles.get(index) {
             self.ssh_profiles_error = None;
             self.ssh_profile_modal_mode = Some(SshProfileModalMode::Edit(index));
-            self.ssh_profile_modal_draft = profile.clone();
+            let mut draft = profile.clone();
+            if matches!(draft.auth_method, SshAuthMethod::Password)
+                && draft.password.is_empty()
+                && let Some(pw) = crate::keychain::get_password(&draft.host, &draft.user)
+            {
+                draft.password = pw;
+            }
+            self.ssh_profile_modal_draft = draft;
             self.ssh_connection_test_status = SshConnectionTestStatus::Idle;
         }
     }
@@ -369,23 +364,23 @@ impl SettingsDraft {
         };
     }
 
-    pub fn save_ssh_profile_modal(&mut self) -> Result<(), String> {
+    pub fn save_ssh_profile_modal(&mut self) -> Result<Option<SshProfile>, String> {
         if self.ssh_profile_modal_mode.is_none() {
-            return Ok(());
+            return Ok(None);
         }
-        if self.ssh_profile_modal_draft.to_profile().is_none() {
+        let Some(profile) = self.ssh_profile_modal_draft.to_profile() else {
             let message = "SSH profile needs a Host before saving.".to_string();
             self.ssh_profiles_error = Some(message.clone());
             return Err(message);
-        }
+        };
 
         match self.ssh_profile_modal_mode {
             Some(SshProfileModalMode::Create) => {
                 self.ssh_profiles.push(self.ssh_profile_modal_draft.clone());
             }
             Some(SshProfileModalMode::Edit(index)) => {
-                if let Some(profile) = self.ssh_profiles.get_mut(index) {
-                    *profile = self.ssh_profile_modal_draft.clone();
+                if let Some(slot) = self.ssh_profiles.get_mut(index) {
+                    *slot = self.ssh_profile_modal_draft.clone();
                 }
             }
             None => {}
@@ -393,7 +388,7 @@ impl SettingsDraft {
 
         self.close_ssh_profile_modal();
         self.ssh_profiles_error = None;
-        Ok(())
+        Ok(Some(profile))
     }
 
     pub fn apply_ssh_profiles_to(&mut self, profiles: &mut Vec<SshProfile>) -> Result<(), String> {

--- a/src/keychain.rs
+++ b/src/keychain.rs
@@ -1,30 +1,63 @@
 use keyring::Entry;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 const SERVICE: &str = "rabbitty-ssh";
 
-fn entry_for(host: &str, user: &str) -> Option<Entry> {
-    let key = if user.is_empty() {
+fn entry_key(host: &str, user: &str) -> String {
+    if user.is_empty() {
         host.to_string()
     } else {
         format!("{user}@{host}")
-    };
-    Entry::new(SERVICE, &key).ok()
+    }
+}
+
+fn entry_for(host: &str, user: &str) -> Option<Entry> {
+    Entry::new(SERVICE, &entry_key(host, user)).ok()
+}
+
+// Process-wide cache so repeated `get_password` calls only hit the OS
+// keychain once per (host, user) — on macOS this avoids re-triggering the
+// "allow access" ACL dialog every connection.
+fn cache() -> &'static Mutex<HashMap<String, String>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 pub fn get_password(host: &str, user: &str) -> Option<String> {
-    entry_for(host, user)?.get_password().ok()
+    let key = entry_key(host, user);
+    {
+        let guard = cache().lock().expect("keychain cache poisoned");
+        if let Some(v) = guard.get(&key) {
+            return Some(v.clone());
+        }
+    }
+    let pw = entry_for(host, user)?.get_password().ok()?;
+    cache()
+        .lock()
+        .expect("keychain cache poisoned")
+        .insert(key, pw.clone());
+    Some(pw)
 }
 
 pub fn set_password(host: &str, user: &str, password: &str) {
     if let Some(entry) = entry_for(host, user) {
         let _ = entry.set_password(password);
     }
+    cache()
+        .lock()
+        .expect("keychain cache poisoned")
+        .insert(entry_key(host, user), password.to_string());
 }
 
 pub fn delete_password(host: &str, user: &str) {
     if let Some(entry) = entry_for(host, user) {
         let _ = entry.delete_credential();
     }
+    cache()
+        .lock()
+        .expect("keychain cache poisoned")
+        .remove(&entry_key(host, user));
 }
 
 #[cfg(test)]
@@ -70,5 +103,21 @@ mod tests {
     fn get_nonexistent_returns_none() {
         let pw = get_password("nonexistent-rabbitty-host.test", "nobody");
         assert!(pw.is_none());
+    }
+
+    #[test]
+    fn cache_serves_subsequent_reads() {
+        let host = "rabbitty-cache-test.local";
+        let user = "cacheuser";
+
+        // Seed the cache via set_password without touching the keychain
+        // (the keyring call may fail silently on CI; cache write still
+        // happens).
+        set_password(host, user, "cached_pw");
+        assert_eq!(get_password(host, user).as_deref(), Some("cached_pw"));
+
+        // Cleanup so other test runs aren't polluted.
+        delete_password(host, user);
+        let _ = entry_for(host, user).map(|e| e.delete_credential());
     }
 }


### PR DESCRIPTION
Process-wide cache so the macOS keychain ACL dialog appears once per `(host, user)` per process instead of every reconnect.

Note: a fresh debug build still prompts once — macOS treats each ad-hoc-signed binary as a new app. A code-signed release build avoids that too.