### PR TITLE
refactor: hot-reload settings

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -27,11 +27,6 @@ theme = "Theme"
 shortcuts = "Shortcuts"
 ssh = "SSH"
 
-[settings.ui]
-window_section = "Window"
-width = "Width"
-height = "Height"
-
 [settings.language]
 section_title = "Language"
 auto = "Auto"

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -27,11 +27,6 @@ theme = "테마"
 shortcuts = "단축키"
 ssh = "SSH"
 
-[settings.ui]
-window_section = "창"
-width = "너비"
-height = "높이"
-
 [settings.language]
 section_title = "언어"
 auto = "자동"

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -11,6 +11,7 @@ use iced::Size;
 use iced::futures::channel::mpsc;
 use iced::keyboard::{Key, Modifiers};
 use iced::widget::combo_box;
+use std::sync::mpsc as std_mpsc;
 
 mod shortcuts;
 mod subscription;
@@ -142,6 +143,22 @@ pub struct App {
     pub(super) pending_settings_updates: Option<crate::config::AppConfigUpdates>,
     #[cfg(target_os = "macos")]
     pub(super) pending_save_on_restart: bool,
+    pub(super) config_save_tx: std_mpsc::Sender<AppConfig>,
+}
+
+fn spawn_config_save_worker() -> std_mpsc::Sender<AppConfig> {
+    let (tx, rx) = std_mpsc::channel::<AppConfig>();
+    std::thread::spawn(move || {
+        while let Ok(mut latest) = rx.recv() {
+            while let Ok(newer) = rx.try_recv() {
+                latest = newer;
+            }
+            if let Err(err) = latest.save() {
+                eprintln!("Failed to save config: {err}");
+            }
+        }
+    });
+    tx
 }
 
 impl App {
@@ -196,6 +213,7 @@ impl App {
             pending_settings_updates: None,
             #[cfg(target_os = "macos")]
             pending_save_on_restart: false,
+            config_save_tx: spawn_config_save_worker(),
         }
     }
 

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -32,6 +32,7 @@ pub enum Message {
     OpenSettingsTab,
     SelectSettingsCategory(SettingsCategory),
     SettingsInputChanged(SettingsField, String),
+    SettingsInputCommitted(SettingsField, String),
     SettingsBlurToggled(bool),
     AddSshProfile,
     EditSshProfile(usize),

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -88,6 +88,7 @@ pub enum Message {
 
     WindowResized(Size),
     ResizeDebounce,
+    SettingsCommitDebounce,
     AnimationTick,
     ApplyWindowStyle,
 
@@ -129,6 +130,9 @@ pub struct App {
     pub(super) resize_debounce_pending: bool,
     pub(super) resize_debounce_seq: u64,
     pub(super) resize_debounce_spawned_seq: u64,
+    pub(super) settings_debounce_pending: bool,
+    pub(super) settings_debounce_seq: u64,
+    pub(super) settings_debounce_spawned_seq: u64,
     pub(super) shell_picker_anim: Animation<bool>,
     pub(super) palette: crate::gui::theme::Palette,
     pub(super) ime_active: bool,
@@ -197,6 +201,9 @@ impl App {
             resize_debounce_pending: false,
             resize_debounce_seq: 0,
             resize_debounce_spawned_seq: 0,
+            settings_debounce_pending: false,
+            settings_debounce_seq: 0,
+            settings_debounce_spawned_seq: 0,
             session_history: SessionHistory::load(),
             palette,
             tab_context_menu: None,

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -205,12 +205,18 @@ impl App {
             Message::SettingsInputChanged(field, value) => {
                 self.settings_draft.update(field, value);
             }
+            Message::SettingsInputCommitted(field, value) => {
+                self.settings_draft.update(field, value);
+                return self.apply_settings(true);
+            }
             Message::SettingsBlurToggled(enabled) => {
                 self.settings_draft.blur_enabled = enabled;
+                return self.apply_settings(true);
             }
             Message::FontSelected(option) => {
                 self.settings_draft
                     .update(SettingsField::TerminalFontSelection, option.value);
+                return self.apply_settings(true);
             }
             Message::ToggleShowAllFonts(show_all) => {
                 self.show_all_fonts = show_all;
@@ -219,6 +225,7 @@ impl App {
                     show_all,
                     self.config.terminal.font_selection.as_deref(),
                 );
+                return self.apply_settings(true);
             }
             #[cfg(target_os = "macos")]
             Message::ConfirmRestartForBlur => {

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -204,9 +204,35 @@ impl App {
             }
             Message::SettingsInputChanged(field, value) => {
                 self.settings_draft.update(field, value);
+                self.settings_debounce_seq = self.settings_debounce_seq.wrapping_add(1);
+                if self.settings_debounce_pending {
+                    return Task::none();
+                }
+                self.settings_debounce_pending = true;
+                self.settings_debounce_spawned_seq = self.settings_debounce_seq;
+                return Task::perform(
+                    async {
+                        std::thread::sleep(std::time::Duration::from_millis(500));
+                    },
+                    |()| Message::SettingsCommitDebounce,
+                );
             }
             Message::SettingsInputCommitted(field, value) => {
                 self.settings_draft.update(field, value);
+                self.settings_debounce_spawned_seq = self.settings_debounce_seq;
+                return self.apply_settings(true);
+            }
+            Message::SettingsCommitDebounce => {
+                if self.settings_debounce_spawned_seq != self.settings_debounce_seq {
+                    self.settings_debounce_spawned_seq = self.settings_debounce_seq;
+                    return Task::perform(
+                        async {
+                            std::thread::sleep(std::time::Duration::from_millis(500));
+                        },
+                        |()| Message::SettingsCommitDebounce,
+                    );
+                }
+                self.settings_debounce_pending = false;
                 return self.apply_settings(true);
             }
             Message::SettingsBlurToggled(enabled) => {

--- a/src/gui/app/update/settings.rs
+++ b/src/gui/app/update/settings.rs
@@ -26,11 +26,15 @@ impl App {
 
         let resize_task = self.apply_updates_to_runtime(updates);
 
-        if save && let Err(err) = self.config.save() {
-            eprintln!("Failed to save config: {err}");
+        if save {
+            self.queue_config_save();
         }
 
         resize_task
+    }
+
+    pub(super) fn queue_config_save(&self) {
+        let _ = self.config_save_tx.send(self.config.clone());
     }
 
     pub(super) fn apply_updates_to_runtime(&mut self, updates: AppConfigUpdates) -> Task<Message> {

--- a/src/gui/app/update/settings.rs
+++ b/src/gui/app/update/settings.rs
@@ -5,7 +5,6 @@ use crate::terminal::TerminalTheme;
 use iced::{Size, Task, window};
 
 impl App {
-    #[allow(dead_code)]
     pub(super) fn apply_settings(&mut self, save: bool) -> Task<Message> {
         let updates = self.settings_draft.to_updates();
 

--- a/src/gui/app/update/settings.rs
+++ b/src/gui/app/update/settings.rs
@@ -38,26 +38,61 @@ impl App {
     }
 
     pub(super) fn apply_updates_to_runtime(&mut self, updates: AppConfigUpdates) -> Task<Message> {
+        let affects_locale = updates.language.is_some();
+        let affects_theme = updates.color_scheme.is_some()
+            || updates.foreground.is_some()
+            || updates.background.is_some()
+            || updates.cursor.is_some()
+            || updates.ansi_colors.is_some()
+            || updates.background_opacity.is_some()
+            || updates.blur_enabled.is_some()
+            || updates.macos_blur_radius.is_some();
+        let affects_grid = updates.window_width.is_some()
+            || updates.window_height.is_some()
+            || updates.terminal_font_selection.is_some()
+            || updates.terminal_font_size.is_some()
+            || updates.terminal_padding_x.is_some()
+            || updates.terminal_padding_y.is_some();
+        let affects_window = updates.window_width.is_some() || updates.window_height.is_some();
+
         self.config.apply_updates(updates);
-        crate::i18n::set_locale(self.config.ui.language.as_deref());
-        self.palette = crate::gui::theme::Palette::from_theme(&self.config.theme);
         self.settings_draft = SettingsDraft::from_config(&self.config);
 
-        let new_size = Size::new(self.config.ui.window_width, self.config.ui.window_height);
-        let resize_task = if (self.window_size.width - new_size.width).abs() > f32::EPSILON
-            || (self.window_size.height - new_size.height).abs() > f32::EPSILON
-        {
-            self.window_size = new_size;
-            window::latest().and_then(move |id| window::resize(id, new_size))
+        if affects_locale {
+            crate::i18n::set_locale(self.config.ui.language.as_deref());
+        }
+        if affects_theme {
+            self.palette = crate::gui::theme::Palette::from_theme(&self.config.theme);
+        }
+
+        let resize_task = if affects_window {
+            let new_size = Size::new(self.config.ui.window_width, self.config.ui.window_height);
+            if (self.window_size.width - new_size.width).abs() > f32::EPSILON
+                || (self.window_size.height - new_size.height).abs() > f32::EPSILON
+            {
+                self.window_size = new_size;
+                window::latest().and_then(move |id| window::resize(id, new_size))
+            } else {
+                Task::none()
+            }
         } else {
             Task::none()
         };
 
-        let (cols, rows) = self.grid_for_size(self.window_size);
-        let theme = TerminalTheme::from_config(&self.config);
-        for tab in &mut self.tabs {
-            tab.resize(cols, rows);
-            tab.set_theme(theme.clone());
+        if affects_grid || affects_theme {
+            let (cols, rows) = self.grid_for_size(self.window_size);
+            let theme = affects_theme.then(|| TerminalTheme::from_config(&self.config));
+            for tab in &mut self.tabs {
+                if affects_grid {
+                    let current = tab.size();
+                    if current.columns != cols || current.lines != rows {
+                        tab.resize(cols, rows);
+                    }
+                }
+                if let Some(ref theme) = theme {
+                    tab.set_theme(theme.clone());
+                }
+            }
         }
 
         resize_task

--- a/src/gui/app/update/tab.rs
+++ b/src/gui/app/update/tab.rs
@@ -149,9 +149,7 @@ impl App {
             ..Default::default()
         };
         let task = self.apply_updates_to_runtime(updates);
-        if let Err(err) = self.config.save() {
-            eprintln!("Failed to save config: {err}");
-        }
+        self.queue_config_save();
         task
     }
 

--- a/src/gui/app/update/terminal.rs
+++ b/src/gui/app/update/terminal.rs
@@ -102,11 +102,10 @@ impl App {
         self.config.apply_updates(updates);
         self.settings_draft
             .sync_window_size(self.config.ui.window_width, self.config.ui.window_height);
-        if ((self.config.ui.window_width - previous_width).abs() > f32::EPSILON
-            || (self.config.ui.window_height - previous_height).abs() > f32::EPSILON)
-            && let Err(err) = self.config.save()
+        if (self.config.ui.window_width - previous_width).abs() > f32::EPSILON
+            || (self.config.ui.window_height - previous_height).abs() > f32::EPSILON
         {
-            eprintln!("Failed to save config: {err}");
+            self.queue_config_save();
         }
 
         let (cols, rows) = self.grid_for_size(size);

--- a/src/gui/app/update/terminal.rs
+++ b/src/gui/app/update/terminal.rs
@@ -100,8 +100,6 @@ impl App {
             ..Default::default()
         };
         self.config.apply_updates(updates);
-        self.settings_draft
-            .sync_window_size(self.config.ui.window_width, self.config.ui.window_height);
         if (self.config.ui.window_width - previous_width).abs() > f32::EPSILON
             || (self.config.ui.window_height - previous_height).abs() > f32::EPSILON
         {

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -563,13 +563,15 @@ pub fn input_row<'a>(
     field: SettingsField,
     palette: Palette,
 ) -> Element<'a, Message> {
+    let commit_msg = Message::SettingsInputCommitted(field, value.to_owned());
     row![
         text(label).size(13).width(Length::Fixed(LABEL_WIDTH)),
         styled_text_input(
             value,
             move |next| Message::SettingsInputChanged(field, next),
             palette
-        ),
+        )
+        .on_submit(commit_msg),
     ]
     .align_y(Alignment::Center)
     .spacing(SPACING_NORMAL)
@@ -584,13 +586,15 @@ pub fn input_row_with_suffix<'a>(
     suffix: &'a str,
     palette: Palette,
 ) -> Element<'a, Message> {
+    let commit_msg = Message::SettingsInputCommitted(field, value.to_owned());
     row![
         text(label).size(13).width(Length::Fixed(LABEL_WIDTH)),
         styled_text_input(
             value,
             move |next| Message::SettingsInputChanged(field, next),
             palette
-        ),
+        )
+        .on_submit(commit_msg),
         text(suffix)
             .size(12)
             .color(palette.text_secondary)
@@ -613,6 +617,7 @@ pub fn color_input_row<'a>(
     let dot_color = parsed
         .map(|rgb| Color::from_rgb8(rgb[0], rgb[1], rgb[2]))
         .unwrap_or(palette.error);
+    let commit_msg = Message::SettingsInputCommitted(field, value.to_owned());
 
     row![
         text(label).size(13).width(Length::Fixed(LABEL_WIDTH)),
@@ -635,7 +640,8 @@ pub fn color_input_row<'a>(
             value,
             move |next| Message::SettingsInputChanged(field, next),
             palette
-        ),
+        )
+        .on_submit(commit_msg),
     ]
     .align_y(Alignment::Center)
     .spacing(SPACING_NORMAL)

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -27,8 +27,6 @@ impl fmt::Display for TerminalFontOption {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingsField {
     UiLanguage,
-    UiWindowWidth,
-    UiWindowHeight,
     TerminalFontSelection,
     TerminalFontSize,
     TerminalPaddingX,
@@ -209,8 +207,6 @@ impl SshProfileDraft {
 #[derive(Debug, Clone)]
 pub struct SettingsDraft {
     pub language: String,
-    pub window_width: String,
-    pub window_height: String,
     pub terminal_font_selection: String,
     pub terminal_font_size: String,
     pub terminal_padding_x: String,
@@ -244,8 +240,6 @@ impl SettingsDraft {
                 .language
                 .clone()
                 .unwrap_or_else(|| "auto".to_string()),
-            window_width: format!("{:.0}", config.ui.window_width),
-            window_height: format!("{:.0}", config.ui.window_height),
             terminal_font_selection: config.terminal.font_selection.clone().unwrap_or_default(),
             terminal_font_size: format!("{:.1}", config.terminal.font_size),
             terminal_padding_x: format!("{:.1}", config.terminal.padding_x),
@@ -420,8 +414,6 @@ impl SettingsDraft {
     pub fn update(&mut self, field: SettingsField, value: String) {
         match field {
             SettingsField::UiLanguage => self.language = value,
-            SettingsField::UiWindowWidth => self.window_width = value,
-            SettingsField::UiWindowHeight => self.window_height = value,
             SettingsField::TerminalFontSelection => self.terminal_font_selection = value,
             SettingsField::TerminalFontSize => self.terminal_font_size = value,
             SettingsField::TerminalPaddingX => self.terminal_padding_x = value,
@@ -448,19 +440,12 @@ impl SettingsDraft {
         }
     }
 
-    pub fn sync_window_size(&mut self, width: f32, height: f32) {
-        self.window_width = format!("{width:.0}");
-        self.window_height = format!("{height:.0}");
-    }
-
     #[allow(dead_code)]
     pub fn to_updates(&self) -> AppConfigUpdates {
         let ansi_colors = crate::terminal::theme::find_preset(&self.color_scheme).map(|p| p.ansi);
 
         let mut updates = AppConfigUpdates {
             language: Some(self.language.clone()),
-            window_width: parse_f32(&self.window_width),
-            window_height: parse_f32(&self.window_height),
             terminal_font_selection: Some(self.terminal_font_selection.clone()),
             terminal_font_size: parse_f32(&self.terminal_font_size),
             terminal_padding_x: parse_f32(&self.terminal_padding_x),

--- a/src/gui/settings/theme.rs
+++ b/src/gui/settings/theme.rs
@@ -216,7 +216,7 @@ fn build_preset_card<'a>(
                 ..Default::default()
             }),
     )
-    .on_press(Message::SettingsInputChanged(
+    .on_press(Message::SettingsInputCommitted(
         SettingsField::ThemeColorScheme,
         name.to_string(),
     ))
@@ -282,7 +282,7 @@ fn color_palette_row<'a>(
                         }
                     }),
             )
-            .on_press(Message::SettingsInputChanged(field, hex))
+            .on_press(Message::SettingsInputCommitted(field, hex))
             .padding(0)
             .style(|_theme: &iced::Theme, _status| button::Style {
                 background: None,
@@ -298,11 +298,13 @@ fn color_palette_row<'a>(
     let swatch_grid = Row::with_children(swatches).spacing(4).width(Length::Fill);
 
     // Current color indicator + hex input
+    let commit_msg = Message::SettingsInputCommitted(field, current_hex.to_owned());
     let hex_input = crate::gui::settings::styled_text_input_small(
         current_hex,
         move |next| Message::SettingsInputChanged(field, next),
         *palette,
-    );
+    )
+    .on_submit(commit_msg);
 
     column![
         row![

--- a/src/gui/settings/ui.rs
+++ b/src/gui/settings/ui.rs
@@ -82,7 +82,7 @@ fn language_button<'a>(
             .size(13)
             .color(if is_selected { accent } else { text_color }),
     )
-    .on_press(Message::SettingsInputChanged(
+    .on_press(Message::SettingsInputCommitted(
         SettingsField::UiLanguage,
         tag.to_string(),
     ))

--- a/src/gui/settings/ui.rs
+++ b/src/gui/settings/ui.rs
@@ -1,6 +1,6 @@
 use crate::config::AppConfig;
 use crate::gui::app::Message;
-use crate::gui::settings::{SettingsDraft, SettingsField, input_row_with_suffix, section};
+use crate::gui::settings::{SettingsDraft, SettingsField, section};
 use crate::gui::theme::{Palette, RADIUS_SMALL, SPACING_NORMAL};
 use crate::i18n::AVAILABLE_LOCALES;
 use iced::widget::{button, column, row, text};
@@ -17,31 +17,7 @@ pub fn view<'a>(
         palette,
     );
 
-    let window_section = section(
-        t!("settings.ui.window_section"),
-        column(vec![
-            input_row_with_suffix(
-                t!("settings.ui.width"),
-                &draft.window_width,
-                SettingsField::UiWindowWidth,
-                "px",
-                palette,
-            ),
-            input_row_with_suffix(
-                t!("settings.ui.height"),
-                &draft.window_height,
-                SettingsField::UiWindowHeight,
-                "px",
-                palette,
-            ),
-        ])
-        .spacing(SPACING_NORMAL)
-        .width(Length::Fill)
-        .into(),
-        palette,
-    );
-
-    column(vec![language_section, window_section])
+    column(vec![language_section])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into()


### PR DESCRIPTION
Replaces the gone Apply & Save flow with hot-reload.

- Pickers/toggles (language, theme, font, blur, ...): instant apply + save
- Text inputs: commit on Enter or after 500ms idle (debounce)
- Window size inputs removed — drag-to-resize already covers it
- Config save runs on a background worker thread with coalescing
- Per-tab resize/theme work is skipped when the update does not affect them (fixes lag on language/picker clicks)