### PR TITLE
feat: install scripts (closes #61, #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ Rabbitty is a terminal emulator chasing `foot`-like memory thrift and cross-plat
 - Cross-platform: consistent on macOS, Linux, Windows.
 - Featureful and fancy: tabs, themes, and modern UX without bloat.
 
+## Install
+
+**Linux / macOS:**
+```sh
+curl -fsSL https://raw.githubusercontent.com/wHoIsDReAmer/RabbiTTY/main/install.sh | sh
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://raw.githubusercontent.com/wHoIsDReAmer/RabbiTTY/main/install.ps1 | iex
+```
+
+**From source (`cargo install`):**
+```sh
+cargo install --git https://github.com/wHoIsDReAmer/RabbiTTY
+```
+
+The Unix script installs the binary to `~/.local/bin/rabbitty` and (on macOS) the `.app` bundle to `~/Applications`. The PowerShell script installs to `%LOCALAPPDATA%\Rabbitty` and adds it to your user PATH.
+
 ## Goals
 
 - [x] SSH Managing

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,53 @@
+# Rabbitty installer for Windows.
+#   irm https://raw.githubusercontent.com/wHoIsDReAmer/RabbiTTY/main/install.ps1 | iex
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'wHoIsDReAmer/RabbiTTY'
+$InstallDir = Join-Path $env:LOCALAPPDATA 'Rabbitty'
+
+function Get-LatestTag {
+    $resp = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+    return $resp.tag_name
+}
+
+$tag = Get-LatestTag
+if (-not $tag) {
+    Write-Error 'failed to resolve latest release tag from GitHub.'
+    exit 1
+}
+
+$asset = "rabbitty-$tag-windows-amd64.zip"
+$url = "https://github.com/$Repo/releases/download/$tag/$asset"
+
+$tmp = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "rabbitty-install-$(Get-Random)") -Force
+try {
+    $zipPath = Join-Path $tmp.FullName $asset
+    Write-Host "Downloading $asset..."
+    Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+
+    Write-Host 'Extracting...'
+    Expand-Archive -Path $zipPath -DestinationPath $tmp.FullName -Force
+
+    $exe = Get-ChildItem -Path $tmp.FullName -Recurse -Filter 'rabbitty.exe' | Select-Object -First 1
+    if (-not $exe) {
+        throw 'rabbitty.exe not found in archive.'
+    }
+
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    Copy-Item -Path $exe.FullName -Destination (Join-Path $InstallDir 'rabbitty.exe') -Force
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (($null -eq $userPath) -or ($userPath -notlike "*$InstallDir*")) {
+        $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
+        [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+        Write-Host "Added $InstallDir to user PATH (restart terminal to pick it up)."
+    }
+
+    Write-Host ""
+    Write-Host "Installed rabbitty.exe to $InstallDir"
+    Write-Host "Run 'rabbitty' in a new terminal to start."
+}
+finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Rabbitty installer for Linux and macOS.
+#   curl -fsSL https://raw.githubusercontent.com/wHoIsDReAmer/RabbiTTY/main/install.sh | sh
+
+set -e
+
+REPO="wHoIsDReAmer/RabbiTTY"
+BIN_DIR="${HOME}/.local/bin"
+APP_DIR="${HOME}/Applications"
+
+err() {
+    printf 'error: %s\n' "$1" >&2
+    exit 1
+}
+
+detect_target() {
+    os=$(uname -s)
+    arch=$(uname -m)
+    case "${os}_${arch}" in
+        Linux_x86_64)        echo "linux-amd64" ;;
+        Linux_aarch64|Linux_arm64) echo "linux-arm64" ;;
+        Darwin_arm64)        echo "macos-arm64" ;;
+        *) echo "" ;;
+    esac
+}
+
+latest_tag() {
+    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | sed -nE 's/.*"tag_name": *"([^"]+)".*/\1/p' \
+        | head -n1
+}
+
+target=$(detect_target)
+[ -n "$target" ] || err "unsupported OS/arch: $(uname -s) $(uname -m). Supported: Linux x86_64/aarch64, macOS arm64."
+
+tag=$(latest_tag)
+[ -n "$tag" ] || err "failed to resolve latest release tag from GitHub."
+
+case "$target" in
+    macos-*) ext="zip" ;;
+    *)       ext="tar.gz" ;;
+esac
+
+asset="rabbitty-${tag}-${target}.${ext}"
+url="https://github.com/${REPO}/releases/download/${tag}/${asset}"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+printf 'Downloading %s...\n' "$asset"
+curl -fsSL -o "${tmp}/${asset}" "$url" || err "download failed: $url"
+
+printf 'Extracting...\n'
+case "$ext" in
+    tar.gz) tar -xzf "${tmp}/${asset}" -C "$tmp" ;;
+    zip)    unzip -q "${tmp}/${asset}" -d "$tmp" ;;
+esac
+
+case "$target" in
+    macos-*)
+        app_src=$(find "$tmp" -name 'Rabbitty.app' -type d -maxdepth 4 | head -n1)
+        [ -n "$app_src" ] || err "Rabbitty.app not found in archive."
+        mkdir -p "$APP_DIR"
+        rm -rf "${APP_DIR}/Rabbitty.app"
+        cp -R "$app_src" "$APP_DIR/"
+        xattr -dr com.apple.quarantine "${APP_DIR}/Rabbitty.app" 2>/dev/null || true
+        mkdir -p "$BIN_DIR"
+        ln -sf "${APP_DIR}/Rabbitty.app/Contents/MacOS/rabbitty" "${BIN_DIR}/rabbitty"
+        printf '\nInstalled Rabbitty.app to %s\n' "$APP_DIR"
+        printf 'CLI symlink at %s/rabbitty\n' "$BIN_DIR"
+        ;;
+    linux-*)
+        bin_src=$(find "$tmp" -name 'rabbitty' -type f -maxdepth 4 | head -n1)
+        [ -n "$bin_src" ] || err "rabbitty binary not found in archive."
+        mkdir -p "$BIN_DIR"
+        install -m 0755 "$bin_src" "${BIN_DIR}/rabbitty"
+        printf '\nInstalled rabbitty to %s/rabbitty\n' "$BIN_DIR"
+        ;;
+esac
+
+case ":${PATH}:" in
+    *:"${BIN_DIR}":*) ;;
+    *)
+        printf '\nWarning: %s is not in your PATH.\n' "$BIN_DIR"
+        printf 'Add this to your shell profile (~/.bashrc, ~/.zshrc, ~/.profile):\n'
+        printf '  export PATH="$HOME/.local/bin:$PATH"\n'
+        ;;
+esac
+
+printf "\nDone. Run 'rabbitty' to start.\n"


### PR DESCRIPTION
Closes #61, #62.

- `install.sh`: Linux x86_64/aarch64 + macOS arm64. Bin to `~/.local/bin/rabbitty`, .app to `~/Applications`, clears macOS quarantine, PATH check.
- `install.ps1`: Windows amd64. Installs to `%LOCALAPPDATA%\Rabbitty` and adds user PATH.
- README: one-liner install commands for both platforms plus cargo install.

Latest release tag is resolved from the GitHub API. Unsupported OS/arch exits with a clear error.