### PR TITLE
fix: anchor terminal selection to scrollback so it follows on scroll

### DIFF
--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -125,6 +125,7 @@ impl App {
 
         // identical to other panes (e.g. Settings) and avoids double blending.
         let clear_color = [0.0, 0.0, 0.0, 0.0];
+        let (display_offset, scroll_history) = active_tab.scroll_position();
         let terminal_widget = TerminalProgram {
             cells,
             grid_size,
@@ -137,12 +138,12 @@ impl App {
             clear_color,
             selection: active_tab.selection,
             mouse_mode: active_tab.mouse_mode(),
+            display_offset,
         }
         .widget()
         .width(Length::Fill)
         .height(Length::Fill);
 
-        let (_scroll_offset, scroll_history) = active_tab.scroll_position();
         let terminal_view: Element<Message> = if scroll_history > 0 {
             let cell_height = self.config.terminal.cell_height.max(1.0);
             let content_height = (scroll_history + dims.lines) as f32 * cell_height;

--- a/src/gui/render/bg.rs
+++ b/src/gui/render/bg.rs
@@ -173,6 +173,7 @@ impl BackgroundPipeline {
         queue: &wgpu::Queue,
         cells: &[CellVisual],
         selection: Option<&Selection>,
+        display_offset: usize,
     ) {
         self.instances.clear();
         let needed = cells.len().saturating_sub(self.instances.capacity());
@@ -180,7 +181,8 @@ impl BackgroundPipeline {
             self.instances.reserve(needed);
         }
         self.instances.extend(cells.iter().map(|cell| {
-            let bg = if selection.is_some_and(|s| s.contains(cell.row, cell.col)) {
+            let bg = if selection.is_some_and(|s| s.contains_at(cell.row, cell.col, display_offset))
+            {
                 super::SELECTION_BG
             } else {
                 cell.bg

--- a/src/gui/render/mod.rs
+++ b/src/gui/render/mod.rs
@@ -1,4 +1,4 @@
-use crate::terminal::{CellVisual, GridPos, Selection, TerminalSize};
+use crate::terminal::{CellVisual, GridPos, Selection, SelectionPoint, TerminalSize};
 use iced::mouse;
 use iced::wgpu;
 use iced::widget::shader::Program as ShaderProgram;
@@ -103,20 +103,24 @@ impl ShaderProgram<Message> for TerminalProgram {
                         );
                     }
                     if state.dragging
-                        && let Some(start) = state.drag_start
+                        && let Some(drag_start) = state.drag_start
                     {
                         let viewport_end = self.pixel_to_grid(pos, bounds);
                         // Translate the current viewport row back into the anchor frame
                         // so the selection follows content when the user scrolls.
                         let delta = self.display_offset as i64 - state.drag_anchor_offset as i64;
-                        let anchored_row = viewport_end.row as i64 - delta;
-                        let start_row = start.row as i64;
-                        if start_row != anchored_row || start.col != viewport_end.col {
+                        let start = SelectionPoint {
+                            row: drag_start.row as i64,
+                            col: drag_start.col,
+                        };
+                        let end = SelectionPoint {
+                            row: viewport_end.row as i64 - delta,
+                            col: viewport_end.col,
+                        };
+                        if start != end {
                             let sel = Selection {
-                                start_row,
-                                start_col: start.col,
-                                end_row: anchored_row,
-                                end_col: viewport_end.col,
+                                start,
+                                end,
                                 anchor_offset: state.drag_anchor_offset,
                             };
                             return Some(

--- a/src/gui/render/mod.rs
+++ b/src/gui/render/mod.rs
@@ -108,17 +108,15 @@ impl ShaderProgram<Message> for TerminalProgram {
                         let viewport_end = self.pixel_to_grid(pos, bounds);
                         // Translate the current viewport row back into the anchor frame
                         // so the selection follows content when the user scrolls.
-                        let delta =
-                            self.display_offset as isize - state.drag_anchor_offset as isize;
-                        let anchored_row = viewport_end.row as isize - delta;
-                        let end = GridPos {
-                            row: anchored_row.max(0) as usize,
-                            col: viewport_end.col,
-                        };
-                        if start != end {
+                        let delta = self.display_offset as i64 - state.drag_anchor_offset as i64;
+                        let anchored_row = viewport_end.row as i64 - delta;
+                        let start_row = start.row as i64;
+                        if start_row != anchored_row || start.col != viewport_end.col {
                             let sel = Selection {
-                                start,
-                                end,
+                                start_row,
+                                start_col: start.col,
+                                end_row: anchored_row,
+                                end_col: viewport_end.col,
                                 anchor_offset: state.drag_anchor_offset,
                             };
                             return Some(

--- a/src/gui/render/mod.rs
+++ b/src/gui/render/mod.rs
@@ -26,6 +26,7 @@ pub struct TerminalProgram {
     pub clear_color: [f32; 4],
     pub selection: Option<Selection>,
     pub mouse_mode: bool,
+    pub display_offset: usize,
 }
 
 impl TerminalProgram {
@@ -53,6 +54,7 @@ impl TerminalProgram {
 pub struct TerminalShaderState {
     dragging: bool,
     drag_start: Option<GridPos>,
+    drag_anchor_offset: usize,
 }
 
 type Message = crate::gui::app::Message;
@@ -84,6 +86,7 @@ impl ShaderProgram<Message> for TerminalProgram {
                     }
                     state.dragging = true;
                     state.drag_start = Some(grid_pos);
+                    state.drag_anchor_offset = self.display_offset;
                     return Some(Action::publish(Message::SelectionChanged(None)).and_capture());
                 }
             }
@@ -102,9 +105,22 @@ impl ShaderProgram<Message> for TerminalProgram {
                     if state.dragging
                         && let Some(start) = state.drag_start
                     {
-                        let end = self.pixel_to_grid(pos, bounds);
+                        let viewport_end = self.pixel_to_grid(pos, bounds);
+                        // Translate the current viewport row back into the anchor frame
+                        // so the selection follows content when the user scrolls.
+                        let delta =
+                            self.display_offset as isize - state.drag_anchor_offset as isize;
+                        let anchored_row = viewport_end.row as isize - delta;
+                        let end = GridPos {
+                            row: anchored_row.max(0) as usize,
+                            col: viewport_end.col,
+                        };
                         if start != end {
-                            let sel = Selection { start, end };
+                            let sel = Selection {
+                                start,
+                                end,
+                                anchor_offset: state.drag_anchor_offset,
+                            };
                             return Some(
                                 Action::publish(Message::SelectionChanged(Some(sel))).and_capture(),
                             );
@@ -158,6 +174,7 @@ impl ShaderProgram<Message> for TerminalProgram {
             terminal_font_selection: self.terminal_font_selection.clone(),
             terminal_font_size: self.terminal_font_size,
             selection: self.selection,
+            display_offset: self.display_offset,
         }
     }
 
@@ -187,6 +204,7 @@ pub struct TerminalPipeline {
     last_offset: [f32; 2],
     last_font_size: f32,
     last_selection: Option<Selection>,
+    last_display_offset: usize,
 }
 
 impl Pipeline for TerminalPipeline {
@@ -202,6 +220,7 @@ impl Pipeline for TerminalPipeline {
             last_offset: [0.0; 2],
             last_font_size: 0.0,
             last_selection: None,
+            last_display_offset: 0,
         }
     }
 }
@@ -216,6 +235,7 @@ pub struct TerminalPrimitive {
     terminal_font_selection: Option<String>,
     terminal_font_size: f32,
     selection: Option<Selection>,
+    display_offset: usize,
 }
 
 impl Primitive for TerminalPrimitive {
@@ -249,7 +269,8 @@ impl Primitive for TerminalPrimitive {
             && viewport == pipeline.last_viewport
             && offset == pipeline.last_offset
             && (font_size - pipeline.last_font_size).abs() < 0.01
-            && self.selection == pipeline.last_selection;
+            && self.selection == pipeline.last_selection
+            && self.display_offset == pipeline.last_display_offset;
 
         if unchanged {
             return;
@@ -262,24 +283,34 @@ impl Primitive for TerminalPrimitive {
         pipeline.last_offset = offset;
         pipeline.last_font_size = font_size;
         pipeline.last_selection = self.selection;
+        pipeline.last_display_offset = self.display_offset;
 
         let cells = self.cells.as_slice();
 
         pipeline
             .bg
             .update_uniforms(queue, cell_size, viewport, offset);
-        pipeline
-            .bg
-            .prepare_instances(device, queue, cells, self.selection.as_ref());
+        pipeline.bg.prepare_instances(
+            device,
+            queue,
+            cells,
+            self.selection.as_ref(),
+            self.display_offset,
+        );
 
         pipeline
             .text
             .apply_terminal_font_selection(device, self.terminal_font_selection.as_deref());
         pipeline.text.set_requested_font_size(font_size);
         pipeline.text.update_uniforms(queue, viewport, offset);
-        pipeline
-            .text
-            .prepare_instances(device, queue, cells, cell_size, self.selection.as_ref());
+        pipeline.text.prepare_instances(
+            device,
+            queue,
+            cells,
+            cell_size,
+            self.selection.as_ref(),
+            self.display_offset,
+        );
     }
 
     fn render(

--- a/src/gui/render/mod.rs
+++ b/src/gui/render/mod.rs
@@ -59,6 +59,16 @@ pub struct TerminalShaderState {
 
 type Message = crate::gui::app::Message;
 
+/// Translate an absolute window-space cursor position into bounds-local
+/// coordinates clamped to the bounds rectangle. Used while dragging so a
+/// selection still updates after the cursor leaves the terminal area.
+fn clamp_to_bounds(absolute: Point, bounds: Rectangle) -> Point {
+    Point::new(
+        (absolute.x - bounds.x).clamp(0.0, bounds.width.max(0.0)),
+        (absolute.y - bounds.y).clamp(0.0, bounds.height.max(0.0)),
+    )
+}
+
 impl ShaderProgram<Message> for TerminalProgram {
     type State = TerminalShaderState;
     type Primitive = TerminalPrimitive;
@@ -91,8 +101,19 @@ impl ShaderProgram<Message> for TerminalProgram {
                 }
             }
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
-                if let Some(pos) = cursor.position_in(bounds) {
-                    if self.mouse_mode && state.dragging {
+                // Use the absolute cursor position while dragging so the selection
+                // still extends after the cursor leaves the terminal bounds.
+                let pos_in = cursor.position_in(bounds);
+                let pos_dragging = state.dragging.then(|| {
+                    pos_in.unwrap_or_else(|| {
+                        cursor
+                            .position()
+                            .map(|p| clamp_to_bounds(p, bounds))
+                            .unwrap_or(Point::ORIGIN)
+                    })
+                });
+                if let Some(pos) = pos_dragging {
+                    if self.mouse_mode {
                         let grid_pos = self.pixel_to_grid(pos, bounds);
                         return Some(
                             Action::publish(Message::TerminalMouseDrag {
@@ -102,9 +123,7 @@ impl ShaderProgram<Message> for TerminalProgram {
                             .and_capture(),
                         );
                     }
-                    if state.dragging
-                        && let Some(drag_start) = state.drag_start
-                    {
+                    if let Some(drag_start) = state.drag_start {
                         let viewport_end = self.pixel_to_grid(pos, bounds);
                         // Translate the current viewport row back into the anchor frame
                         // so the selection follows content when the user scrolls.

--- a/src/gui/render/text/mod.rs
+++ b/src/gui/render/text/mod.rs
@@ -301,6 +301,7 @@ impl TextPipelineData {
         cells: &[CellVisual],
         cell_size: [f32; 2],
         selection: Option<&crate::terminal::Selection>,
+        display_offset: usize,
     ) {
         let cell_width = cell_size[0];
         let cell_height = cell_size[1];
@@ -346,11 +347,12 @@ impl TextPipelineData {
             let origin_y = cell_y + top_margin - self.line_min_y;
             let pos = [origin_x + info.bearing[0], origin_y + info.bearing[1]];
 
-            let bg_color = if selection.is_some_and(|s| s.contains(cell.row, cell.col)) {
-                super::SELECTION_BG
-            } else {
-                cell.bg
-            };
+            let bg_color =
+                if selection.is_some_and(|s| s.contains_at(cell.row, cell.col, display_offset)) {
+                    super::SELECTION_BG
+                } else {
+                    cell.bg
+                };
             self.glyph_instances.push(GlyphInstance {
                 pos,
                 size: info.size,

--- a/src/gui/tab.rs
+++ b/src/gui/tab.rs
@@ -119,35 +119,32 @@ impl TerminalTab {
         let cells = self.engine.render_cells();
         let size = self.engine.size();
         let (current_offset, _) = self.engine.scroll_position();
-        let delta = current_offset as i64 - sel.anchor_offset as i64;
-        let ((start_row, start_col), (end_row, end_col)) = sel.ordered();
+        let delta = sel.delta(current_offset);
+        let (start, end) = sel.ordered();
         let mut result = String::new();
-        for row in start_row..=end_row {
+        for row in start.row..=end.row {
             // Selection rows live in the anchor frame; translate to the
             // current viewport before reading cells.
             let viewport_row = row + delta;
-            if viewport_row < 0 || viewport_row as usize >= size.lines {
-                if row != end_row {
-                    result.push('\n');
+            let row_in_view = (0..size.lines as i64).contains(&viewport_row);
+            if row_in_view {
+                let viewport_row = viewport_row as usize;
+                let col_start = if row == start.row { start.col } else { 0 };
+                let col_end = if row == end.row {
+                    end.col
+                } else {
+                    size.columns.saturating_sub(1)
+                };
+                for col in col_start..=col_end {
+                    let idx = viewport_row * size.columns + col;
+                    if let Some(cell) = cells.get(idx) {
+                        result.push(cell.ch);
+                    }
                 }
-                continue;
+                let trimmed_len = result.trim_end_matches(' ').len();
+                result.truncate(trimmed_len);
             }
-            let viewport_row = viewport_row as usize;
-            let col_start = if row == start_row { start_col } else { 0 };
-            let col_end = if row == end_row {
-                end_col
-            } else {
-                size.columns.saturating_sub(1)
-            };
-            for col in col_start..=col_end {
-                let idx = viewport_row * size.columns + col;
-                if let Some(cell) = cells.get(idx) {
-                    result.push(cell.ch);
-                }
-            }
-            let trimmed_len = result.trim_end_matches(' ').len();
-            result.truncate(trimmed_len);
-            if row != end_row {
+            if row != end.row {
                 result.push('\n');
             }
         }

--- a/src/gui/tab.rs
+++ b/src/gui/tab.rs
@@ -119,23 +119,23 @@ impl TerminalTab {
         let cells = self.engine.render_cells();
         let size = self.engine.size();
         let (current_offset, _) = self.engine.scroll_position();
-        let delta = current_offset as isize - sel.anchor_offset as isize;
-        let (start, end) = sel.ordered();
+        let delta = current_offset as i64 - sel.anchor_offset as i64;
+        let ((start_row, start_col), (end_row, end_col)) = sel.ordered();
         let mut result = String::new();
-        for row in start.row..=end.row {
+        for row in start_row..=end_row {
             // Selection rows live in the anchor frame; translate to the
             // current viewport before reading cells.
-            let viewport_row = row as isize + delta;
+            let viewport_row = row + delta;
             if viewport_row < 0 || viewport_row as usize >= size.lines {
-                if row != end.row {
+                if row != end_row {
                     result.push('\n');
                 }
                 continue;
             }
             let viewport_row = viewport_row as usize;
-            let col_start = if row == start.row { start.col } else { 0 };
-            let col_end = if row == end.row {
-                end.col
+            let col_start = if row == start_row { start_col } else { 0 };
+            let col_end = if row == end_row {
+                end_col
             } else {
                 size.columns.saturating_sub(1)
             };
@@ -147,7 +147,7 @@ impl TerminalTab {
             }
             let trimmed_len = result.trim_end_matches(' ').len();
             result.truncate(trimmed_len);
-            if row != end.row {
+            if row != end_row {
                 result.push('\n');
             }
         }

--- a/src/gui/tab.rs
+++ b/src/gui/tab.rs
@@ -118,9 +118,21 @@ impl TerminalTab {
         let sel = self.selection.as_ref().filter(|s| !s.is_empty())?;
         let cells = self.engine.render_cells();
         let size = self.engine.size();
+        let (current_offset, _) = self.engine.scroll_position();
+        let delta = current_offset as isize - sel.anchor_offset as isize;
         let (start, end) = sel.ordered();
         let mut result = String::new();
         for row in start.row..=end.row {
+            // Selection rows live in the anchor frame; translate to the
+            // current viewport before reading cells.
+            let viewport_row = row as isize + delta;
+            if viewport_row < 0 || viewport_row as usize >= size.lines {
+                if row != end.row {
+                    result.push('\n');
+                }
+                continue;
+            }
+            let viewport_row = viewport_row as usize;
             let col_start = if row == start.row { start.col } else { 0 };
             let col_end = if row == end.row {
                 end.col
@@ -128,7 +140,7 @@ impl TerminalTab {
                 size.columns.saturating_sub(1)
             };
             for col in col_start..=col_end {
-                let idx = row * size.columns + col;
+                let idx = viewport_row * size.columns + col;
                 if let Some(cell) = cells.get(idx) {
                     result.push(cell.ch);
                 }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -39,82 +39,86 @@ pub struct GridPos {
     pub col: usize,
 }
 
+/// A row/column pair in a selection's anchor frame. Rows are signed so the
+/// selection can extend into scrollback past the top of the viewport that was
+/// active when the drag started.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SelectionPoint {
+    pub row: i64,
+    pub col: usize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Selection {
-    /// Anchor-frame row of the selection's start. Signed so the selection can
-    /// extend into scrollback (negative rows) once it crosses the top of the
-    /// viewport that was active when the drag started.
-    pub start_row: i64,
-    pub start_col: usize,
-    pub end_row: i64,
-    pub end_col: usize,
+    pub start: SelectionPoint,
+    pub end: SelectionPoint,
     /// `display_offset` at the moment the selection was anchored.
     pub anchor_offset: usize,
 }
 
 impl Selection {
-    pub fn ordered(&self) -> ((i64, usize), (i64, usize)) {
-        if self.start_row < self.end_row
-            || (self.start_row == self.end_row && self.start_col <= self.end_col)
-        {
-            (
-                (self.start_row, self.start_col),
-                (self.end_row, self.end_col),
-            )
-        } else {
-            (
-                (self.end_row, self.end_col),
-                (self.start_row, self.start_col),
-            )
-        }
+    /// Signed delta from the anchor frame to the supplied display offset.
+    /// Positive when the viewport has scrolled toward older content since the
+    /// anchor was captured.
+    pub fn delta(&self, current_offset: usize) -> i64 {
+        current_offset as i64 - self.anchor_offset as i64
     }
 
-    /// Map a current-viewport row back into the selection's anchor frame.
-    fn anchor_row(&self, viewport_row: usize, current_offset: usize) -> i64 {
-        let delta = current_offset as i64 - self.anchor_offset as i64;
-        viewport_row as i64 - delta
+    /// Returns the selection's two endpoints in reading order.
+    pub fn ordered(&self) -> (SelectionPoint, SelectionPoint) {
+        let earlier_first = self.start.row < self.end.row
+            || (self.start.row == self.end.row && self.start.col <= self.end.col);
+        if earlier_first {
+            (self.start, self.end)
+        } else {
+            (self.end, self.start)
+        }
     }
 
     pub fn contains_at(&self, viewport_row: usize, col: usize, current_offset: usize) -> bool {
-        let row = self.anchor_row(viewport_row, current_offset);
-        let ((start_row, start_col), (end_row, end_col)) = self.ordered();
-        if row < start_row || row > end_row {
+        let row = viewport_row as i64 - self.delta(current_offset);
+        let (start, end) = self.ordered();
+        if row < start.row || row > end.row {
             return false;
         }
-        if start_row == end_row {
-            return col >= start_col && col <= end_col;
+        if start.row == end.row {
+            return col >= start.col && col <= end.col;
         }
-        if row == start_row {
-            return col >= start_col;
+        if row == start.row {
+            return col >= start.col;
         }
-        if row == end_row {
-            return col <= end_col;
+        if row == end.row {
+            return col <= end.col;
         }
         true
     }
 
     pub fn is_empty(&self) -> bool {
-        self.start_row == self.end_row && self.start_col == self.end_col
+        self.start == self.end
     }
 }
 
 #[cfg(test)]
 mod selection_tests {
-    use super::Selection;
+    use super::{Selection, SelectionPoint};
 
-    fn sel(start_row: i64, end_row: i64, anchor: usize) -> Selection {
+    fn sel(start: (i64, usize), end: (i64, usize), anchor: usize) -> Selection {
         Selection {
-            start_row,
-            start_col: 0,
-            end_row,
-            end_col: 9,
+            start: SelectionPoint {
+                row: start.0,
+                col: start.1,
+            },
+            end: SelectionPoint {
+                row: end.0,
+                col: end.1,
+            },
             anchor_offset: anchor,
         }
     }
 
     #[test]
     fn highlight_follows_content_when_scrolling_up() {
-        let s = sel(5, 10, 0);
+        let s = sel((5, 0), (10, 9), 0);
         assert!(!s.contains_at(7, 5, 3));
         assert!(s.contains_at(8, 5, 3));
         assert!(s.contains_at(13, 5, 3));
@@ -123,7 +127,7 @@ mod selection_tests {
 
     #[test]
     fn highlight_follows_content_when_scrolling_down() {
-        let s = sel(5, 10, 5);
+        let s = sel((5, 0), (10, 9), 5);
         assert!(!s.contains_at(1, 5, 2));
         assert!(s.contains_at(2, 5, 2));
         assert!(s.contains_at(7, 5, 2));
@@ -134,20 +138,11 @@ mod selection_tests {
     fn highlight_extends_into_scrollback_for_negative_anchor_rows() {
         // Drag started at (5, 9) and ended at (-3, 0) — natural diagonal
         // selection sweeping up-left across the original viewport top.
-        let s = Selection {
-            start_row: 5,
-            start_col: 9,
-            end_row: -3,
-            end_col: 0,
-            anchor_offset: 0,
-        };
-        // At offset 0 the row -3 sits above the viewport so it isn't visible,
-        // but rows 0..5 are part of the selection.
+        let s = sel((5, 9), (-3, 0), 0);
         assert!(s.contains_at(0, 5, 0));
         assert!(s.contains_at(5, 5, 0));
         assert!(!s.contains_at(6, 5, 0));
-        // Scrolled up by 3: anchor row -3 now sits at viewport row 0 and is
-        // the ordered-start of the selection (full row from col 0).
+        // Scrolled up by 3: anchor row -3 now sits at viewport row 0.
         assert!(s.contains_at(0, 5, 3));
         assert!(s.contains_at(8, 5, 3));
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -41,84 +41,80 @@ pub struct GridPos {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Selection {
-    pub start: GridPos,
-    pub end: GridPos,
-    /// `display_offset` at the moment the selection was anchored. Selection
-    /// rows are stored in this frame so they follow content during scrolls.
+    /// Anchor-frame row of the selection's start. Signed so the selection can
+    /// extend into scrollback (negative rows) once it crosses the top of the
+    /// viewport that was active when the drag started.
+    pub start_row: i64,
+    pub start_col: usize,
+    pub end_row: i64,
+    pub end_col: usize,
+    /// `display_offset` at the moment the selection was anchored.
     pub anchor_offset: usize,
 }
 
 impl Selection {
-    pub fn ordered(&self) -> (GridPos, GridPos) {
-        if self.start.row < self.end.row
-            || (self.start.row == self.end.row && self.start.col <= self.end.col)
+    pub fn ordered(&self) -> ((i64, usize), (i64, usize)) {
+        if self.start_row < self.end_row
+            || (self.start_row == self.end_row && self.start_col <= self.end_col)
         {
-            (self.start, self.end)
+            (
+                (self.start_row, self.start_col),
+                (self.end_row, self.end_col),
+            )
         } else {
-            (self.end, self.start)
+            (
+                (self.end_row, self.end_col),
+                (self.start_row, self.start_col),
+            )
         }
     }
 
-    /// Translate a current-viewport row back into the selection's anchor frame.
-    fn anchor_row(&self, viewport_row: usize, current_offset: usize) -> Option<usize> {
-        let delta = current_offset as isize - self.anchor_offset as isize;
-        let anchored = viewport_row as isize - delta;
-        if anchored < 0 {
-            None
-        } else {
-            Some(anchored as usize)
-        }
+    /// Map a current-viewport row back into the selection's anchor frame.
+    fn anchor_row(&self, viewport_row: usize, current_offset: usize) -> i64 {
+        let delta = current_offset as i64 - self.anchor_offset as i64;
+        viewport_row as i64 - delta
     }
 
     pub fn contains_at(&self, viewport_row: usize, col: usize, current_offset: usize) -> bool {
-        let Some(row) = self.anchor_row(viewport_row, current_offset) else {
-            return false;
-        };
-        let (start, end) = self.ordered();
-        if row < start.row || row > end.row {
+        let row = self.anchor_row(viewport_row, current_offset);
+        let ((start_row, start_col), (end_row, end_col)) = self.ordered();
+        if row < start_row || row > end_row {
             return false;
         }
-        if start.row == end.row {
-            return col >= start.col && col <= end.col;
+        if start_row == end_row {
+            return col >= start_col && col <= end_col;
         }
-        if row == start.row {
-            return col >= start.col;
+        if row == start_row {
+            return col >= start_col;
         }
-        if row == end.row {
-            return col <= end.col;
+        if row == end_row {
+            return col <= end_col;
         }
         true
     }
 
     pub fn is_empty(&self) -> bool {
-        self.start == self.end
+        self.start_row == self.end_row && self.start_col == self.end_col
     }
 }
 
 #[cfg(test)]
 mod selection_tests {
-    use super::{GridPos, Selection};
+    use super::Selection;
 
-    fn sel(start_row: usize, end_row: usize, anchor: usize) -> Selection {
+    fn sel(start_row: i64, end_row: i64, anchor: usize) -> Selection {
         Selection {
-            start: GridPos {
-                row: start_row,
-                col: 0,
-            },
-            end: GridPos {
-                row: end_row,
-                col: 9,
-            },
+            start_row,
+            start_col: 0,
+            end_row,
+            end_col: 9,
             anchor_offset: anchor,
         }
     }
 
     #[test]
     fn highlight_follows_content_when_scrolling_up() {
-        // Anchored at offset 0, selection covers rows 5..10.
         let s = sel(5, 10, 0);
-        // At offset 3 (scrolled up by 3) the content moved down by 3, so the
-        // highlight should now cover viewport rows 8..13.
         assert!(!s.contains_at(7, 5, 3));
         assert!(s.contains_at(8, 5, 3));
         assert!(s.contains_at(13, 5, 3));
@@ -127,9 +123,7 @@ mod selection_tests {
 
     #[test]
     fn highlight_follows_content_when_scrolling_down() {
-        // Anchored at offset 5, selection covers rows 5..10.
         let s = sel(5, 10, 5);
-        // Scrolling down to offset 2 (delta = -3) shifts highlight up by 3.
         assert!(!s.contains_at(1, 5, 2));
         assert!(s.contains_at(2, 5, 2));
         assert!(s.contains_at(7, 5, 2));
@@ -137,12 +131,25 @@ mod selection_tests {
     }
 
     #[test]
-    fn highlight_drops_off_when_anchor_above_viewport() {
-        // delta=10, anchor row stored as 0. Viewport row 0 maps to -10 → false.
-        let s = sel(0, 2, 0);
-        assert!(!s.contains_at(0, 5, 10));
-        assert!(s.contains_at(10, 5, 10));
-        assert!(s.contains_at(12, 5, 10));
+    fn highlight_extends_into_scrollback_for_negative_anchor_rows() {
+        // Drag started at (5, 9) and ended at (-3, 0) — natural diagonal
+        // selection sweeping up-left across the original viewport top.
+        let s = Selection {
+            start_row: 5,
+            start_col: 9,
+            end_row: -3,
+            end_col: 0,
+            anchor_offset: 0,
+        };
+        // At offset 0 the row -3 sits above the viewport so it isn't visible,
+        // but rows 0..5 are part of the selection.
+        assert!(s.contains_at(0, 5, 0));
+        assert!(s.contains_at(5, 5, 0));
+        assert!(!s.contains_at(6, 5, 0));
+        // Scrolled up by 3: anchor row -3 now sits at viewport row 0 and is
+        // the ordered-start of the selection (full row from col 0).
+        assert!(s.contains_at(0, 5, 3));
+        assert!(s.contains_at(8, 5, 3));
     }
 }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -95,6 +95,57 @@ impl Selection {
     }
 }
 
+#[cfg(test)]
+mod selection_tests {
+    use super::{GridPos, Selection};
+
+    fn sel(start_row: usize, end_row: usize, anchor: usize) -> Selection {
+        Selection {
+            start: GridPos {
+                row: start_row,
+                col: 0,
+            },
+            end: GridPos {
+                row: end_row,
+                col: 9,
+            },
+            anchor_offset: anchor,
+        }
+    }
+
+    #[test]
+    fn highlight_follows_content_when_scrolling_up() {
+        // Anchored at offset 0, selection covers rows 5..10.
+        let s = sel(5, 10, 0);
+        // At offset 3 (scrolled up by 3) the content moved down by 3, so the
+        // highlight should now cover viewport rows 8..13.
+        assert!(!s.contains_at(7, 5, 3));
+        assert!(s.contains_at(8, 5, 3));
+        assert!(s.contains_at(13, 5, 3));
+        assert!(!s.contains_at(14, 5, 3));
+    }
+
+    #[test]
+    fn highlight_follows_content_when_scrolling_down() {
+        // Anchored at offset 5, selection covers rows 5..10.
+        let s = sel(5, 10, 5);
+        // Scrolling down to offset 2 (delta = -3) shifts highlight up by 3.
+        assert!(!s.contains_at(1, 5, 2));
+        assert!(s.contains_at(2, 5, 2));
+        assert!(s.contains_at(7, 5, 2));
+        assert!(!s.contains_at(8, 5, 2));
+    }
+
+    #[test]
+    fn highlight_drops_off_when_anchor_above_viewport() {
+        // delta=10, anchor row stored as 0. Viewport row 0 maps to -10 → false.
+        let s = sel(0, 2, 0);
+        assert!(!s.contains_at(0, 5, 10));
+        assert!(s.contains_at(10, 5, 10));
+        assert!(s.contains_at(12, 5, 10));
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct CellVisual {
     pub ch: char,

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -43,6 +43,9 @@ pub struct GridPos {
 pub struct Selection {
     pub start: GridPos,
     pub end: GridPos,
+    /// `display_offset` at the moment the selection was anchored. Selection
+    /// rows are stored in this frame so they follow content during scrolls.
+    pub anchor_offset: usize,
 }
 
 impl Selection {
@@ -56,7 +59,21 @@ impl Selection {
         }
     }
 
-    pub fn contains(&self, row: usize, col: usize) -> bool {
+    /// Translate a current-viewport row back into the selection's anchor frame.
+    fn anchor_row(&self, viewport_row: usize, current_offset: usize) -> Option<usize> {
+        let delta = current_offset as isize - self.anchor_offset as isize;
+        let anchored = viewport_row as isize - delta;
+        if anchored < 0 {
+            None
+        } else {
+            Some(anchored as usize)
+        }
+    }
+
+    pub fn contains_at(&self, viewport_row: usize, col: usize, current_offset: usize) -> bool {
+        let Some(row) = self.anchor_row(viewport_row, current_offset) else {
+            return false;
+        };
         let (start, end) = self.ordered();
         if row < start.row || row > end.row {
             return false;


### PR DESCRIPTION
Drag-selecting text and then scrolling left the highlight stuck at the same viewport rows while the content moved. Standard terminals (iTerm2, Alacritty, Warp) anchor selection to buffer coordinates so it tracks the content.

- `Selection` stores `anchor_offset` — the `display_offset` snapshot at the moment the drag started.
- `contains_at(row, col, current_offset)` and `selected_text` translate the anchor row back into the current viewport (`row + (current - anchor)`).
- Shader program captures `drag_anchor_offset` on mouse-down and feeds it through `TerminalProgram` / `TerminalPrimitive` so the bg/text passes apply the same translation.
- Pipeline cache key now includes `display_offset` so highlight rebuilds when scrolling without buffer changes.