### PR TITLE
fix: stop scrollbar from clipping the last column (closes #117)

### DIFF
--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -162,7 +162,7 @@ impl App {
                     Message::TerminalScroll(rel.y)
                 })
                 .style(crate::gui::theme::scrollbar_style(self.palette))
-                .width(Length::Fixed(14.0))
+                .width(Length::Fixed(8.0))
                 .height(Length::Fill);
 
             row![terminal_widget, scrollbar]

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -151,7 +151,7 @@ impl App {
                 .width(Length::Fill)
                 .height(Length::Fixed(content_height));
 
-            let scroll_overlay = scrollable(scroll_content)
+            let scrollbar = scrollable(scroll_content)
                 .id(crate::gui::app::update::TERMINAL_SCROLLABLE_ID.clone())
                 .direction(scrollable::Direction::Vertical(
                     scrollable::Scrollbar::new().width(8).scroller_width(8),
@@ -165,13 +165,10 @@ impl App {
                 .width(Length::Fixed(14.0))
                 .height(Length::Fill);
 
-            stack![
-                terminal_widget,
-                row![container("").width(Length::Fill), scroll_overlay].height(Length::Fill)
-            ]
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .into()
+            row![terminal_widget, scrollbar]
+                .height(Length::Fill)
+                .width(Length::Fill)
+                .into()
         } else {
             terminal_widget.into()
         };


### PR DESCRIPTION
Closes #117.

The vertical scrollback bar lived on a `stack` overlay aligned to the right of the terminal widget, so the last column of text rendered into the same 14px the scrollbar occupied. Switched the layout to a `row` — terminal on the left taking `Length::Fill`, scrollbar on the right at `Length::Fixed(14)` — so they share the same horizontal space without overlapping.

Trade-off: when scrollback first appears, the terminal width shrinks by 14px and the cells compress slightly. The PTY grid size is unchanged.