### PR TITLE
fix: gate dialog module to macOS so linux clippy passes

### DIFF
--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 mod dialog;
 mod password_prompt;
 mod settings;


### PR DESCRIPTION
The previous PR removed the `#[cfg(target_os = "macos")]` guard on `mod dialog` so the password prompt could live alongside it, but `DialogButton` and `confirm_dialog` are only consumed by the macOS-only blur-restart flow. On Linux clippy reports them as dead code and fails with `-D warnings`. Restored the cfg guard — `password_prompt` is in its own module and unaffected.