### PR TITLE
fix: position ime popup and tab context menu at the cursor

### DIFF
--- a/src/gui/app/subscription.rs
+++ b/src/gui/app/subscription.rs
@@ -73,6 +73,9 @@ impl App {
                 Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                     Some(Message::TabDragRelease)
                 }
+                Event::Mouse(mouse::Event::CursorMoved { position }) => {
+                    Some(Message::CursorMoved(position))
+                }
                 Event::Mouse(mouse::Event::WheelScrolled { delta })
                     if !matches!(status, event::Status::Captured) =>
                 {

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -224,6 +224,7 @@ impl App {
         ImeEnabled::new(with_drawer)
             .preedit(self.ime_preedit.clone())
             .cursor_cell(Some(cursor_cell))
+            .text_size(self.config.terminal.font_size)
             .into()
     }
 

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -209,8 +209,21 @@ impl App {
             terminal_view
         };
 
+        let (cursor_col, cursor_row) = active_tab.cursor_position();
+        let cursor_cell = crate::gui::components::ime_wrapper::CursorCell {
+            col: cursor_col,
+            row: cursor_row,
+            grid_cols: dims.columns,
+            grid_rows: dims.lines,
+            padding: [
+                self.config.terminal.padding_x,
+                self.config.terminal.padding_y,
+            ],
+        };
+
         ImeEnabled::new(with_drawer)
             .preedit(self.ime_preedit.clone())
+            .cursor_cell(Some(cursor_cell))
             .into()
     }
 

--- a/src/gui/components/ime_wrapper.rs
+++ b/src/gui/components/ime_wrapper.rs
@@ -25,6 +25,7 @@ pub struct ImeEnabled<'a, Message, Theme, Renderer> {
     content: Element<'a, Message, Theme, Renderer>,
     preedit: Option<(String, Option<Range<usize>>)>,
     cursor_cell: Option<CursorCell>,
+    text_size: f32,
 }
 
 impl<'a, Message, Theme, Renderer> ImeEnabled<'a, Message, Theme, Renderer> {
@@ -33,6 +34,7 @@ impl<'a, Message, Theme, Renderer> ImeEnabled<'a, Message, Theme, Renderer> {
             content: content.into(),
             preedit: None,
             cursor_cell: None,
+            text_size: 14.0,
         }
     }
 
@@ -43,6 +45,11 @@ impl<'a, Message, Theme, Renderer> ImeEnabled<'a, Message, Theme, Renderer> {
 
     pub fn cursor_cell(mut self, cell: Option<CursorCell>) -> Self {
         self.cursor_cell = cell;
+        self
+    }
+
+    pub fn text_size(mut self, size: f32) -> Self {
+        self.text_size = size;
         self
     }
 }
@@ -110,10 +117,11 @@ where
             Event::Window(iced::window::Event::RedrawRequested(_))
         ) {
             let bounds = layout.bounds();
+            let text_size = self.text_size;
             let preedit = self.preedit.as_ref().map(|(text, selection)| Preedit {
                 content: text.as_str(),
                 selection: selection.clone(),
-                text_size: Some(Pixels(14.0)),
+                text_size: Some(Pixels(text_size)),
             });
             let cursor_rect = self
                 .cursor_cell

--- a/src/gui/components/ime_wrapper.rs
+++ b/src/gui/components/ime_wrapper.rs
@@ -10,10 +10,21 @@ use iced::{Element, Event, Length, Pixels, Rectangle, Size, Vector};
 
 use std::ops::Range;
 
+/// Grid cell that the IME composition window should anchor under.
+#[derive(Debug, Clone, Copy)]
+pub struct CursorCell {
+    pub col: usize,
+    pub row: usize,
+    pub grid_cols: usize,
+    pub grid_rows: usize,
+    pub padding: [f32; 2],
+}
+
 /// A wrapper widget that enables IME input for its child.
 pub struct ImeEnabled<'a, Message, Theme, Renderer> {
     content: Element<'a, Message, Theme, Renderer>,
     preedit: Option<(String, Option<Range<usize>>)>,
+    cursor_cell: Option<CursorCell>,
 }
 
 impl<'a, Message, Theme, Renderer> ImeEnabled<'a, Message, Theme, Renderer> {
@@ -21,11 +32,17 @@ impl<'a, Message, Theme, Renderer> ImeEnabled<'a, Message, Theme, Renderer> {
         Self {
             content: content.into(),
             preedit: None,
+            cursor_cell: None,
         }
     }
 
     pub fn preedit(mut self, preedit: Option<(String, Option<Range<usize>>)>) -> Self {
         self.preedit = preedit;
+        self
+    }
+
+    pub fn cursor_cell(mut self, cell: Option<CursorCell>) -> Self {
+        self.cursor_cell = cell;
         self
     }
 }
@@ -98,11 +115,17 @@ where
                 selection: selection.clone(),
                 text_size: Some(Pixels(14.0)),
             });
+            let cursor_rect = self
+                .cursor_cell
+                .map(|cell| cursor_pixel_rect(cell, bounds))
+                .unwrap_or_else(|| {
+                    Rectangle::new(
+                        iced::Point::new(bounds.x, bounds.y + bounds.height),
+                        Size::ZERO,
+                    )
+                });
             shell.request_input_method(&InputMethod::Enabled {
-                cursor: Rectangle::new(
-                    iced::Point::new(bounds.x, bounds.y + bounds.height),
-                    Size::ZERO,
-                ),
+                cursor: cursor_rect,
                 purpose: Purpose::Terminal,
                 preedit,
             });
@@ -153,6 +176,16 @@ where
             .as_widget_mut()
             .overlay(tree, layout, renderer, viewport, translation)
     }
+}
+
+fn cursor_pixel_rect(cell: CursorCell, bounds: Rectangle) -> Rectangle {
+    let inner_w = (bounds.width - cell.padding[0] * 2.0).max(1.0);
+    let inner_h = (bounds.height - cell.padding[1] * 2.0).max(1.0);
+    let cell_w = inner_w / cell.grid_cols.max(1) as f32;
+    let cell_h = inner_h / cell.grid_rows.max(1) as f32;
+    let x = bounds.x + cell.padding[0] + cell.col as f32 * cell_w;
+    let y = bounds.y + cell.padding[1] + (cell.row + 1) as f32 * cell_h;
+    Rectangle::new(iced::Point::new(x, y), Size::new(cell_w, 0.0))
 }
 
 impl<'a, Message, Theme, Renderer> From<ImeEnabled<'a, Message, Theme, Renderer>>

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -47,9 +47,7 @@ pub fn tab_bar<'a>(
             .on_press(Message::TabSelected(index))
             .on_enter(Message::TabDragHover(index));
         if is_terminal_tab {
-            tab_item = tab_item
-                .on_right_press(Message::ShowTabContextMenu(index))
-                .on_move(Message::CursorMoved);
+            tab_item = tab_item.on_right_press(Message::ShowTabContextMenu(index));
         }
         tab_elements.push(tab_item.into());
     }

--- a/src/gui/tab.rs
+++ b/src/gui/tab.rs
@@ -114,6 +114,10 @@ impl TerminalTab {
         self.engine.scroll_position()
     }
 
+    pub fn cursor_position(&self) -> (usize, usize) {
+        self.engine.cursor_position()
+    }
+
     pub fn selected_text(&self) -> Option<String> {
         let sel = self.selection.as_ref().filter(|s| !s.is_empty())?;
         let cells = self.engine.render_cells();

--- a/src/terminal/engine.rs
+++ b/src/terminal/engine.rs
@@ -141,6 +141,12 @@ impl TerminalEngine {
         self.term.mode().contains(TermMode::ALT_SCREEN)
     }
 
+    /// Current text cursor as `(col, row)` in viewport coordinates.
+    pub fn cursor_position(&self) -> (usize, usize) {
+        let point = self.term.grid().cursor.point;
+        (point.column.0, point.line.0.max(0) as usize)
+    }
+
     fn build_cells_into(&self, cells: &mut Vec<CellVisual>) {
         let RenderableContent {
             display_iter,


### PR DESCRIPTION
Two issues were anchoring popups to fixed corners instead of the cursor:

- **IME composition window** was always rendered at the bottom-left of the terminal widget (`bounds.x, bounds.y + bounds.height`). Now plumbs the terminal text cursor's grid cell into `ImeEnabled`, converts it to a pixel rect against the layout bounds, and uses that as the IME cursor anchor.
- **Tab right-click context menu** read `cursor_position` that was being filled by `mouse_area.on_move` — that callback reports a bounds-relative point, not the absolute window coordinate the menu padding expected. Switched to a window-level subscription on `mouse::Event::CursorMoved { position }` so the stored point matches what the menu's `Padding::top/left` consumes, and dropped the redundant per-tab `on_move` wiring.