### PR TITLE
feat: bracketed paste mode for multi-line clipboard contents

### DIFF
--- a/.github/workflows/compile_check.yml
+++ b/.github/workflows/compile_check.yml
@@ -17,15 +17,16 @@ jobs:
           - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+      - uses: actions/checkout@v4
 
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target
+          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('Cargo.lock') }}
 
       - run: cargo build

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -533,7 +533,18 @@ impl App {
                     && let Some(tab) = self.active_session_mut()
                     && let crate::gui::tab::TerminalSession::Active(session) = &tab.session
                 {
-                    let _ = session.send_bytes(text.as_bytes());
+                    // pasted contents cannot break out of bracketed-paste framing.
+                    let sanitized = text
+                        .replace("\r\n", "\r")
+                        .replace('\n', "\r")
+                        .replace("\x1b[200~", "")
+                        .replace("\x1b[201~", "");
+                    let payload = if tab.bracketed_paste() {
+                        format!("\x1b[200~{sanitized}\x1b[201~").into_bytes()
+                    } else {
+                        sanitized.into_bytes()
+                    };
+                    let _ = session.send_bytes(&payload);
                 }
             }
             Message::ImeStateChanged(active) => {

--- a/src/gui/tab.rs
+++ b/src/gui/tab.rs
@@ -179,6 +179,11 @@ impl TerminalTab {
         self.engine.alt_screen()
     }
 
+    /// Returns true when the running program has enabled bracketed paste.
+    pub fn bracketed_paste(&self) -> bool {
+        self.engine.bracketed_paste()
+    }
+
     /// Send scroll as arrow key sequences (for alt screen without mouse mode).
     pub fn send_scroll_as_arrows(&self, lines: i32) {
         let TerminalSession::Active(session) = &self.session else {

--- a/src/terminal/engine.rs
+++ b/src/terminal/engine.rs
@@ -141,6 +141,12 @@ impl TerminalEngine {
         self.term.mode().contains(TermMode::ALT_SCREEN)
     }
 
+    /// Returns true when the running program has enabled bracketed paste
+    /// (`\e[?2004h`).
+    pub fn bracketed_paste(&self) -> bool {
+        self.term.mode().contains(TermMode::BRACKETED_PASTE)
+    }
+
     /// Current text cursor as `(col, row)` in viewport coordinates.
     pub fn cursor_position(&self) -> (usize, usize) {
         let point = self.term.grid().cursor.point;


### PR DESCRIPTION
Multi-line clipboard pastes used to be sent verbatim, so every `\n` was treated like Enter and lines executed one-by-one in the shell. Now the paste flow:

- Normalizes `\r\n`/`\n` to `\r` so newlines match what the Enter key already sends.
- Strips any embedded `\\e[200~` / `\\e[201~` markers from the clipboard contents so a hostile clipboard cannot break out of paste framing.
- If the shell has enabled bracketed paste mode (`\\e[?2004h` — bash 4+, zsh, fish all do by default), wraps the payload in `\\e[200~`/`\\e[201~` so the shell knows the lines came from a paste and does not auto-execute them.

Plumbs `bracketed_paste()` from `TermMode::BRACKETED_PASTE` through the engine and `TerminalTab` for the paste handler to query.