### PR TITLE
fix: spawn shells in $HOME instead of inherited cwd

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -95,6 +95,7 @@ impl Session {
         let options = Options {
             shell: Some(Shell::new(spec.program, spec.args)),
             env: spec.env.into_iter().collect(),
+            working_directory: dirs::home_dir(),
             ..Default::default()
         };
 
@@ -173,6 +174,7 @@ impl Session {
         let options = Options {
             shell: Some(Shell::new(spec.program, spec.args)),
             env: spec.env.into_iter().collect(),
+            working_directory: dirs::home_dir(),
             ..Default::default()
         };
 


### PR DESCRIPTION
Released .app launched from Finder inherits a working directory of `/`, so the spawned shell starts at root. Both the unix and windows `Session::spawn` paths used `..Default::default()` which leaves alacritty's `Options.working_directory` as `None`, deferring to the launcher's cwd.

Set `working_directory: dirs::home_dir()` so shells consistently open in `$HOME` like Terminal.app / iTerm2 / Warp do, regardless of how the binary was launched.