### PR TITLE
feat: configurable scrollback buffer size (#126)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,7 @@ pub const DEFAULT_SHORTCUT_DUPLICATE_TAB: &str = "Ctrl+Shift+D";
 pub const DEFAULT_TERMINAL_FONT_SIZE: f32 = 14.0;
 pub const DEFAULT_TERMINAL_PADDING_X: f32 = 4.0;
 pub const DEFAULT_TERMINAL_PADDING_Y: f32 = 4.0;
+pub const DEFAULT_TERMINAL_SCROLLBACK: usize = 10_000;
 const DEJAVU_SANS_MONO: &[u8] = include_bytes!("../fonts/DejaVuSansMono.ttf");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
@@ -128,6 +129,7 @@ pub struct TerminalConfig {
     pub font_size: f32,
     pub padding_x: f32,
     pub padding_y: f32,
+    pub scrollback_lines: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -193,6 +195,7 @@ struct TerminalFileConfig {
     font_size: Option<f32>,
     padding_x: Option<f32>,
     padding_y: Option<f32>,
+    scrollback_lines: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -249,6 +252,7 @@ pub struct AppConfigUpdates {
     pub shortcut_font_size_decrease: Option<String>,
     pub shortcut_font_size_reset: Option<String>,
     pub shortcut_duplicate_tab: Option<String>,
+    pub terminal_scrollback: Option<usize>,
 }
 
 impl Default for AppConfig {
@@ -267,6 +271,7 @@ impl Default for AppConfig {
                 font_size: DEFAULT_TERMINAL_FONT_SIZE,
                 padding_x: DEFAULT_TERMINAL_PADDING_X,
                 padding_y: DEFAULT_TERMINAL_PADDING_Y,
+                scrollback_lines: DEFAULT_TERMINAL_SCROLLBACK,
             },
             theme: ThemeConfig {
                 color_scheme: "Catppuccin Mocha".to_string(),
@@ -340,6 +345,10 @@ impl AppConfig {
         }
         if let Some(py) = updates.terminal_padding_y {
             self.terminal.padding_y = sanitize_padding(py);
+        }
+        if let Some(lines) = updates.terminal_scrollback {
+            self.terminal.scrollback_lines =
+                sanitize_scrollback(lines, self.terminal.scrollback_lines);
         }
         if let Some(scheme) = updates.color_scheme {
             self.theme.color_scheme = scheme;
@@ -453,6 +462,10 @@ impl AppConfig {
             }
             if let Some(py) = term.padding_y {
                 self.terminal.padding_y = sanitize_padding(py);
+            }
+            if let Some(lines) = term.scrollback_lines {
+                self.terminal.scrollback_lines =
+                    sanitize_scrollback(lines, self.terminal.scrollback_lines);
             }
         }
 
@@ -641,6 +654,14 @@ fn sanitize_terminal_font_selection(value: &str) -> Option<String> {
     }
 }
 
+fn sanitize_scrollback(value: usize, fallback: usize) -> usize {
+    if (100..=1_000_000).contains(&value) {
+        value
+    } else {
+        fallback
+    }
+}
+
 fn sanitize_terminal_font_size(value: f32, fallback: f32) -> f32 {
     if value.is_finite() && (6.0..=72.0).contains(&value) {
         value
@@ -778,6 +799,7 @@ impl From<&AppConfig> for FileConfig {
                 font_size: Some(config.terminal.font_size),
                 padding_x: Some(config.terminal.padding_x),
                 padding_y: Some(config.terminal.padding_y),
+                scrollback_lines: Some(config.terminal.scrollback_lines),
             }),
             theme: Some(ThemeFileConfig {
                 color_scheme: if config.theme.color_scheme.is_empty() {
@@ -1217,6 +1239,49 @@ mod tests {
         let toml_str = toml::to_string_pretty(&file).unwrap();
 
         assert!(!toml_str.contains("[[ssh_profiles]]"));
+    }
+
+    #[test]
+    fn scrollback_sanitize_clamps_to_valid_range() {
+        let mut config = AppConfig::default();
+        assert_eq!(
+            config.terminal.scrollback_lines,
+            DEFAULT_TERMINAL_SCROLLBACK
+        );
+
+        // Value within range is accepted
+        config.apply_updates(AppConfigUpdates {
+            terminal_scrollback: Some(500),
+            ..Default::default()
+        });
+        assert_eq!(config.terminal.scrollback_lines, 500);
+
+        // Value below minimum keeps previous
+        config.apply_updates(AppConfigUpdates {
+            terminal_scrollback: Some(99),
+            ..Default::default()
+        });
+        assert_eq!(config.terminal.scrollback_lines, 500);
+
+        // Value above maximum keeps previous
+        config.apply_updates(AppConfigUpdates {
+            terminal_scrollback: Some(1_000_001),
+            ..Default::default()
+        });
+        assert_eq!(config.terminal.scrollback_lines, 500);
+
+        // Boundary values are accepted
+        config.apply_updates(AppConfigUpdates {
+            terminal_scrollback: Some(100),
+            ..Default::default()
+        });
+        assert_eq!(config.terminal.scrollback_lines, 100);
+
+        config.apply_updates(AppConfigUpdates {
+            terminal_scrollback: Some(1_000_000),
+            ..Default::default()
+        });
+        assert_eq!(config.terminal.scrollback_lines, 1_000_000);
     }
 
     #[test]

--- a/src/gui/app/update/tab.rs
+++ b/src/gui/app/update/tab.rs
@@ -40,8 +40,15 @@ impl App {
         self.next_tab_id = self.next_tab_id.wrapping_add(1);
         let display_name = shell.display_name();
         self.session_history.record((&shell).into(), display_name);
-        let new_tab =
-            crate::gui::tab::TerminalTab::from_shell(shell, cols, rows, theme, tab_id, sender);
+        let new_tab = crate::gui::tab::TerminalTab::from_shell(
+            shell,
+            cols,
+            rows,
+            theme,
+            tab_id,
+            sender,
+            &self.config,
+        );
         self.tabs.push(new_tab);
         self.active_tab = self.tabs.len() - 1;
         self.show_shell_picker = false;

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -31,6 +31,7 @@ pub enum SettingsField {
     TerminalFontSize,
     TerminalPaddingX,
     TerminalPaddingY,
+    TerminalScrollback,
     ThemeColorScheme,
     ThemeForeground,
     ThemeBackground,
@@ -211,6 +212,7 @@ pub struct SettingsDraft {
     pub terminal_font_size: String,
     pub terminal_padding_x: String,
     pub terminal_padding_y: String,
+    pub terminal_scrollback: String,
     pub color_scheme: String,
     pub foreground: String,
     pub background: String,
@@ -244,6 +246,7 @@ impl SettingsDraft {
             terminal_font_size: format!("{:.1}", config.terminal.font_size),
             terminal_padding_x: format!("{:.1}", config.terminal.padding_x),
             terminal_padding_y: format!("{:.1}", config.terminal.padding_y),
+            terminal_scrollback: config.terminal.scrollback_lines.to_string(),
             color_scheme: config.theme.color_scheme.clone(),
             foreground: format_rgb(config.theme.foreground),
             background: format_rgb(config.theme.background),
@@ -418,6 +421,7 @@ impl SettingsDraft {
             SettingsField::TerminalFontSize => self.terminal_font_size = value,
             SettingsField::TerminalPaddingX => self.terminal_padding_x = value,
             SettingsField::TerminalPaddingY => self.terminal_padding_y = value,
+            SettingsField::TerminalScrollback => self.terminal_scrollback = value,
             SettingsField::ThemeColorScheme => {
                 self.color_scheme = value.clone();
                 if let Some(preset) = crate::terminal::theme::find_preset(&value) {
@@ -450,6 +454,7 @@ impl SettingsDraft {
             terminal_font_size: parse_f32(&self.terminal_font_size),
             terminal_padding_x: parse_f32(&self.terminal_padding_x),
             terminal_padding_y: parse_f32(&self.terminal_padding_y),
+            terminal_scrollback: self.terminal_scrollback.trim().parse::<usize>().ok(),
             color_scheme: Some(self.color_scheme.clone()),
             foreground: parse_hex_color(&self.foreground),
             background: parse_hex_color(&self.background),

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -86,7 +86,22 @@ pub fn view<'a>(
         palette,
     );
 
-    column(vec![font_section, padding_section])
+    let scrollback_section = section(
+        "Scrollback",
+        column(vec![input_row_with_suffix(
+            "Scrollback",
+            &draft.terminal_scrollback,
+            SettingsField::TerminalScrollback,
+            "lines",
+            palette,
+        )])
+        .spacing(SPACING_NORMAL)
+        .width(Length::Fill)
+        .into(),
+        palette,
+    );
+
+    column(vec![font_section, padding_section, scrollback_section])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into()

--- a/src/gui/tab.rs
+++ b/src/gui/tab.rs
@@ -1,4 +1,4 @@
-use crate::config::SshProfile;
+use crate::config::{AppConfig, SshProfile};
 use crate::gui::sftp::SftpDrawerState;
 use crate::session::{LaunchSpec, OutputEvent, Session, SessionError};
 use crate::terminal::{CellVisual, Selection, TerminalEngine, TerminalSize, TerminalTheme};
@@ -35,8 +35,17 @@ impl TerminalTab {
         theme: TerminalTheme,
         id: u64,
         output_tx: mpsc::UnboundedSender<OutputEvent>,
+        config: &AppConfig,
     ) -> Self {
-        Self::launch(shell, columns, lines, theme, id, output_tx)
+        Self::launch(
+            shell,
+            columns,
+            lines,
+            theme,
+            id,
+            output_tx,
+            config.terminal.scrollback_lines,
+        )
     }
 
     fn launch(
@@ -46,6 +55,7 @@ impl TerminalTab {
         theme: TerminalTheme,
         id: u64,
         output_tx: mpsc::UnboundedSender<OutputEvent>,
+        scrollback_lines: usize,
     ) -> Self {
         let size = TerminalSize::new(columns, lines);
 
@@ -73,7 +83,9 @@ impl TerminalTab {
             }
         };
 
-        let engine = TerminalEngine::new(size, 10_000, writer, theme);
+        // scrollback_lines is read from config at tab creation time;
+        // changing the setting later applies only to newly created tabs.
+        let engine = TerminalEngine::new(size, scrollback_lines, writer, theme);
 
         Self {
             id,


### PR DESCRIPTION
First increment of #126. The scrollback buffer was hardcoded to 10,000 lines in `gui/tab.rs`.

- `AppConfig.terminal.scrollback_lines` (default 10,000), serialized to the config file.
- Sanitized to 100..=1,000,000 on load/update.
- Settings → Terminal gets a "Scrollback" input row (lines).
- Read at tab creation; changing it applies to newly created tabs (existing tabs keep their buffer).