### PR TITLE
feat: configurable mouse wheel scroll speed (#126)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,7 @@ pub const DEFAULT_TERMINAL_PADDING_Y: f32 = 4.0;
 pub const DEFAULT_TERMINAL_SCROLLBACK: usize = 10_000;
 pub const DEFAULT_BRACKETED_PASTE: bool = true;
 pub const DEFAULT_MULTILINE_PASTE_CONFIRM: bool = false;
+pub const DEFAULT_TERMINAL_SCROLL_MULTIPLIER: f32 = 1.0;
 const DEJAVU_SANS_MONO: &[u8] = include_bytes!("../fonts/DejaVuSansMono.ttf");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
@@ -134,6 +135,7 @@ pub struct TerminalConfig {
     pub scrollback_lines: usize,
     pub bracketed_paste: bool,
     pub multiline_paste_confirm: bool,
+    pub scroll_multiplier: f32,
 }
 
 #[derive(Debug, Clone)]
@@ -202,6 +204,7 @@ struct TerminalFileConfig {
     scrollback_lines: Option<usize>,
     bracketed_paste: Option<bool>,
     multiline_paste_confirm: Option<bool>,
+    scroll_multiplier: Option<f32>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -261,6 +264,7 @@ pub struct AppConfigUpdates {
     pub terminal_scrollback: Option<usize>,
     pub terminal_bracketed_paste: Option<bool>,
     pub terminal_multiline_paste_confirm: Option<bool>,
+    pub terminal_scroll_multiplier: Option<f32>,
 }
 
 impl Default for AppConfig {
@@ -282,6 +286,7 @@ impl Default for AppConfig {
                 scrollback_lines: DEFAULT_TERMINAL_SCROLLBACK,
                 bracketed_paste: DEFAULT_BRACKETED_PASTE,
                 multiline_paste_confirm: DEFAULT_MULTILINE_PASTE_CONFIRM,
+                scroll_multiplier: DEFAULT_TERMINAL_SCROLL_MULTIPLIER,
             },
             theme: ThemeConfig {
                 color_scheme: "Catppuccin Mocha".to_string(),
@@ -365,6 +370,10 @@ impl AppConfig {
         }
         if let Some(enabled) = updates.terminal_multiline_paste_confirm {
             self.terminal.multiline_paste_confirm = enabled;
+        }
+        if let Some(mult) = updates.terminal_scroll_multiplier {
+            self.terminal.scroll_multiplier =
+                sanitize_scroll_multiplier(mult, self.terminal.scroll_multiplier);
         }
         if let Some(scheme) = updates.color_scheme {
             self.theme.color_scheme = scheme;
@@ -488,6 +497,10 @@ impl AppConfig {
             }
             if let Some(enabled) = term.multiline_paste_confirm {
                 self.terminal.multiline_paste_confirm = enabled;
+            }
+            if let Some(mult) = term.scroll_multiplier {
+                self.terminal.scroll_multiplier =
+                    sanitize_scroll_multiplier(mult, self.terminal.scroll_multiplier);
             }
         }
 
@@ -684,6 +697,14 @@ fn sanitize_scrollback(value: usize, fallback: usize) -> usize {
     }
 }
 
+fn sanitize_scroll_multiplier(value: f32, fallback: f32) -> f32 {
+    if value.is_finite() && (0.1..=10.0).contains(&value) {
+        value
+    } else {
+        fallback
+    }
+}
+
 fn sanitize_terminal_font_size(value: f32, fallback: f32) -> f32 {
     if value.is_finite() && (6.0..=72.0).contains(&value) {
         value
@@ -824,6 +845,7 @@ impl From<&AppConfig> for FileConfig {
                 scrollback_lines: Some(config.terminal.scrollback_lines),
                 bracketed_paste: Some(config.terminal.bracketed_paste),
                 multiline_paste_confirm: Some(config.terminal.multiline_paste_confirm),
+                scroll_multiplier: Some(config.terminal.scroll_multiplier),
             }),
             theme: Some(ThemeFileConfig {
                 color_scheme: if config.theme.color_scheme.is_empty() {

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -594,6 +594,7 @@ impl App {
                 }
             }
             Message::TerminalWheelScroll(raw_delta) => {
+                let raw_delta = raw_delta * self.config.terminal.scroll_multiplier;
                 if self.active_tab != SETTINGS_TAB_INDEX
                     && let Some(tab) = self.tabs.get_mut(self.active_tab)
                 {

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -32,6 +32,7 @@ pub enum SettingsField {
     TerminalPaddingX,
     TerminalPaddingY,
     TerminalScrollback,
+    TerminalScrollSpeed,
     ThemeColorScheme,
     ThemeForeground,
     ThemeBackground,
@@ -213,6 +214,7 @@ pub struct SettingsDraft {
     pub terminal_padding_x: String,
     pub terminal_padding_y: String,
     pub terminal_scrollback: String,
+    pub terminal_scroll_speed: String,
     pub bracketed_paste: bool,
     pub multiline_paste_confirm: bool,
     pub color_scheme: String,
@@ -249,6 +251,7 @@ impl SettingsDraft {
             terminal_padding_x: format!("{:.1}", config.terminal.padding_x),
             terminal_padding_y: format!("{:.1}", config.terminal.padding_y),
             terminal_scrollback: config.terminal.scrollback_lines.to_string(),
+            terminal_scroll_speed: format!("{:.1}", config.terminal.scroll_multiplier),
             bracketed_paste: config.terminal.bracketed_paste,
             multiline_paste_confirm: config.terminal.multiline_paste_confirm,
             color_scheme: config.theme.color_scheme.clone(),
@@ -426,6 +429,7 @@ impl SettingsDraft {
             SettingsField::TerminalPaddingX => self.terminal_padding_x = value,
             SettingsField::TerminalPaddingY => self.terminal_padding_y = value,
             SettingsField::TerminalScrollback => self.terminal_scrollback = value,
+            SettingsField::TerminalScrollSpeed => self.terminal_scroll_speed = value,
             SettingsField::ThemeColorScheme => {
                 self.color_scheme = value.clone();
                 if let Some(preset) = crate::terminal::theme::find_preset(&value) {
@@ -459,6 +463,7 @@ impl SettingsDraft {
             terminal_padding_x: parse_f32(&self.terminal_padding_x),
             terminal_padding_y: parse_f32(&self.terminal_padding_y),
             terminal_scrollback: self.terminal_scrollback.trim().parse::<usize>().ok(),
+            terminal_scroll_multiplier: parse_f32(&self.terminal_scroll_speed),
             terminal_bracketed_paste: Some(self.bracketed_paste),
             terminal_multiline_paste_confirm: Some(self.multiline_paste_confirm),
             color_scheme: Some(self.color_scheme.clone()),

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -87,14 +87,23 @@ pub fn view<'a>(
     );
 
     let scrollback_section = section(
-        "Scrollback",
-        column(vec![input_row_with_suffix(
-            "Scrollback",
-            &draft.terminal_scrollback,
-            SettingsField::TerminalScrollback,
-            "lines",
-            palette,
-        )])
+        "Scrolling",
+        column(vec![
+            input_row_with_suffix(
+                "Scrollback",
+                &draft.terminal_scrollback,
+                SettingsField::TerminalScrollback,
+                "lines",
+                palette,
+            ),
+            input_row_with_suffix(
+                "Scroll speed",
+                &draft.terminal_scroll_speed,
+                SettingsField::TerminalScrollSpeed,
+                "x",
+                palette,
+            ),
+        ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),


### PR DESCRIPTION
Third increment of #126. Stacked on #128.

- `terminal.scroll_multiplier` (default 1.0) — multiplies wheel scroll delta. Sanitized to 0.1..=10.0.
- Settings → Terminal "Scrolling" section gains a "Scroll speed" input (x).
- Applied at the top of the `TerminalWheelScroll` handler, so it affects all three scroll modes (mouse-reporting, alt-screen arrows, normal scrollback).

Base is `feat/setting-paste` since these increments stack on the same config/settings files.