### PR TITLE
fix: remove redundant macOS restart hint from Blur setting

### DIFF
--- a/src/gui/settings/theme.rs
+++ b/src/gui/settings/theme.rs
@@ -78,13 +78,10 @@ pub fn view<'a>(
 
     let blur_section = section(
         "Blur",
-        column(vec![
-            toggle_row("Enable blur", draft.blur_enabled),
-            hint_text("On macOS, changing this requires restart.", palette),
-        ])
-        .spacing(SPACING_NORMAL)
-        .width(Length::Fill)
-        .into(),
+        column(vec![toggle_row("Enable blur", draft.blur_enabled)])
+            .spacing(SPACING_NORMAL)
+            .width(Length::Fill)
+            .into(),
         palette,
     );
 


### PR DESCRIPTION
Blur 설정의 "On macOS, changing this requires restart." 안내 문구를 제거합니다. macOS에서는 별도의 재시작 확인 다이얼로그가 이미 표시되므로 중복이고, 다른 OS에서는 무의미한 문구입니다.