### PR TITLE
feat: configurable cursor shape and blink

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,7 @@ pub const DEFAULT_TERMINAL_SCROLLBACK: usize = 10_000;
 pub const DEFAULT_BRACKETED_PASTE: bool = true;
 pub const DEFAULT_MULTILINE_PASTE_CONFIRM: bool = false;
 pub const DEFAULT_TERMINAL_SCROLL_MULTIPLIER: f32 = 1.0;
+pub const DEFAULT_CURSOR_BLINK: bool = true;
 const DEJAVU_SANS_MONO: &[u8] = include_bytes!("../fonts/DejaVuSansMono.ttf");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
@@ -78,6 +79,31 @@ pub enum SshAuthMethod {
     KeyFile,
     #[default]
     Password,
+}
+
+/// Visual shape of the terminal text cursor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CursorShape {
+    #[default]
+    Block,
+    Bar,
+    Underline,
+}
+
+impl CursorShape {
+    pub const ALL: [Self; 3] = [Self::Block, Self::Bar, Self::Underline];
+}
+
+impl std::fmt::Display for CursorShape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::Block => "Block",
+            Self::Bar => "Bar",
+            Self::Underline => "Underline",
+        };
+        f.write_str(label)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -136,6 +162,8 @@ pub struct TerminalConfig {
     pub bracketed_paste: bool,
     pub multiline_paste_confirm: bool,
     pub scroll_multiplier: f32,
+    pub cursor_shape: CursorShape,
+    pub cursor_blink: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -205,6 +233,8 @@ struct TerminalFileConfig {
     bracketed_paste: Option<bool>,
     multiline_paste_confirm: Option<bool>,
     scroll_multiplier: Option<f32>,
+    cursor_shape: Option<CursorShape>,
+    cursor_blink: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -265,6 +295,8 @@ pub struct AppConfigUpdates {
     pub terminal_bracketed_paste: Option<bool>,
     pub terminal_multiline_paste_confirm: Option<bool>,
     pub terminal_scroll_multiplier: Option<f32>,
+    pub terminal_cursor_shape: Option<CursorShape>,
+    pub terminal_cursor_blink: Option<bool>,
 }
 
 impl Default for AppConfig {
@@ -287,6 +319,8 @@ impl Default for AppConfig {
                 bracketed_paste: DEFAULT_BRACKETED_PASTE,
                 multiline_paste_confirm: DEFAULT_MULTILINE_PASTE_CONFIRM,
                 scroll_multiplier: DEFAULT_TERMINAL_SCROLL_MULTIPLIER,
+                cursor_shape: CursorShape::default(),
+                cursor_blink: DEFAULT_CURSOR_BLINK,
             },
             theme: ThemeConfig {
                 color_scheme: "Catppuccin Mocha".to_string(),
@@ -374,6 +408,12 @@ impl AppConfig {
         if let Some(mult) = updates.terminal_scroll_multiplier {
             self.terminal.scroll_multiplier =
                 sanitize_scroll_multiplier(mult, self.terminal.scroll_multiplier);
+        }
+        if let Some(shape) = updates.terminal_cursor_shape {
+            self.terminal.cursor_shape = shape;
+        }
+        if let Some(enabled) = updates.terminal_cursor_blink {
+            self.terminal.cursor_blink = enabled;
         }
         if let Some(scheme) = updates.color_scheme {
             self.theme.color_scheme = scheme;
@@ -501,6 +541,12 @@ impl AppConfig {
             if let Some(mult) = term.scroll_multiplier {
                 self.terminal.scroll_multiplier =
                     sanitize_scroll_multiplier(mult, self.terminal.scroll_multiplier);
+            }
+            if let Some(shape) = term.cursor_shape {
+                self.terminal.cursor_shape = shape;
+            }
+            if let Some(enabled) = term.cursor_blink {
+                self.terminal.cursor_blink = enabled;
             }
         }
 
@@ -846,6 +892,8 @@ impl From<&AppConfig> for FileConfig {
                 bracketed_paste: Some(config.terminal.bracketed_paste),
                 multiline_paste_confirm: Some(config.terminal.multiline_paste_confirm),
                 scroll_multiplier: Some(config.terminal.scroll_multiplier),
+                cursor_shape: Some(config.terminal.cursor_shape),
+                cursor_blink: Some(config.terminal.cursor_blink),
             }),
             theme: Some(ThemeFileConfig {
                 color_scheme: if config.theme.color_scheme.is_empty() {

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -37,6 +37,8 @@ pub enum Message {
     SettingsBlurToggled(bool),
     SettingsBracketedPasteToggled(bool),
     SettingsMultilinePasteConfirmToggled(bool),
+    SettingsCursorShapeSelected(crate::config::CursorShape),
+    SettingsCursorBlinkToggled(bool),
     AddSshProfile,
     EditSshProfile(usize),
     RequestRemoveSshProfile(usize),
@@ -137,6 +139,7 @@ pub enum Message {
     ResizeDebounce,
     SettingsCommitDebounce,
     AnimationTick,
+    CursorBlink,
     ApplyWindowStyle,
 
     FontSelected(TerminalFontOption),
@@ -202,6 +205,8 @@ pub struct App {
     pub(super) password_prompt: Option<PasswordPromptState>,
     /// Text waiting for multiline-paste confirmation.
     pub(super) pending_paste: Option<String>,
+    /// Current on/off phase of the blinking cursor.
+    pub(super) cursor_blink_on: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -286,6 +291,7 @@ impl App {
             ssh_config_profiles: crate::ssh::user_config::load(),
             password_prompt: None,
             pending_paste: None,
+            cursor_blink_on: true,
         }
     }
 

--- a/src/gui/app/subscription.rs
+++ b/src/gui/app/subscription.rs
@@ -19,8 +19,18 @@ impl App {
             Subscription::none()
         };
 
+        let cursor_blink = if self.config.terminal.cursor_blink
+            && self.active_tab != super::SETTINGS_TAB_INDEX
+            && self.tabs.get(self.active_tab).is_some()
+        {
+            time::every(std::time::Duration::from_millis(530)).map(|_| Message::CursorBlink)
+        } else {
+            Subscription::none()
+        };
+
         Subscription::batch([
             animation_tick,
+            cursor_blink,
             Subscription::run(|| {
                 stream::channel(100, async |mut output| {
                     let (sender, mut receiver) = mpsc::unbounded();

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -456,6 +456,14 @@ impl App {
                 self.settings_draft.multiline_paste_confirm = enabled;
                 return self.apply_settings(true);
             }
+            Message::SettingsCursorShapeSelected(shape) => {
+                self.settings_draft.cursor_shape = shape;
+                return self.apply_settings(true);
+            }
+            Message::SettingsCursorBlinkToggled(enabled) => {
+                self.settings_draft.cursor_blink = enabled;
+                return self.apply_settings(true);
+            }
             Message::FontSelected(option) => {
                 self.settings_draft
                     .update(SettingsField::TerminalFontSelection, option.value);
@@ -650,6 +658,9 @@ impl App {
                         tab.sftp.open = false;
                     }
                 }
+            }
+            Message::CursorBlink => {
+                self.cursor_blink_on = !self.cursor_blink_on;
             }
             Message::ResizeDebounce => {
                 if self.resize_debounce_seq != self.resize_debounce_spawned_seq {

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -156,8 +156,7 @@ impl App {
         let cursor = active_tab
             .cursor_cell()
             .map(|(col, row)| [col as u32, row as u32]);
-        let cursor_visible =
-            !self.config.terminal.cursor_blink || self.cursor_blink_on;
+        let cursor_visible = !self.config.terminal.cursor_blink || self.cursor_blink_on;
         let terminal_widget = TerminalProgram {
             cells,
             grid_size,

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -153,6 +153,11 @@ impl App {
         // identical to other panes (e.g. Settings) and avoids double blending.
         let clear_color = [0.0, 0.0, 0.0, 0.0];
         let (display_offset, scroll_history) = active_tab.scroll_position();
+        let cursor = active_tab
+            .cursor_cell()
+            .map(|(col, row)| [col as u32, row as u32]);
+        let cursor_visible =
+            !self.config.terminal.cursor_blink || self.cursor_blink_on;
         let terminal_widget = TerminalProgram {
             cells,
             grid_size,
@@ -166,6 +171,10 @@ impl App {
             selection: active_tab.selection,
             mouse_mode: active_tab.mouse_mode(),
             display_offset,
+            cursor,
+            cursor_shape: self.config.terminal.cursor_shape,
+            cursor_visible,
+            cursor_color: active_tab.cursor_color(),
         }
         .widget()
         .width(Length::Fill)

--- a/src/gui/render/bg.rs
+++ b/src/gui/render/bg.rs
@@ -1,3 +1,4 @@
+use crate::config::CursorShape;
 use crate::terminal::{CellVisual, Selection};
 use bytemuck::{Pod, Zeroable};
 use iced::wgpu::{self, util::DeviceExt};
@@ -14,6 +15,8 @@ struct Uniforms {
 #[repr(C)]
 struct InstanceRaw {
     pos: [u32; 2],
+    rect_offset: [f32; 2],
+    rect_size: [f32; 2],
     color: [f32; 4],
 }
 
@@ -111,7 +114,9 @@ impl BackgroundPipeline {
                         step_mode: wgpu::VertexStepMode::Instance,
                         attributes: &wgpu::vertex_attr_array![
                             1 => Uint32x2,
-                            2 => Float32x4
+                            2 => Float32x2,
+                            3 => Float32x2,
+                            4 => Float32x4
                         ],
                     },
                 ],
@@ -167,6 +172,7 @@ impl BackgroundPipeline {
         queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn prepare_instances(
         &mut self,
         device: &wgpu::Device,
@@ -174,6 +180,9 @@ impl BackgroundPipeline {
         cells: &[CellVisual],
         selection: Option<&Selection>,
         display_offset: usize,
+        cursor: Option<[u32; 2]>,
+        cursor_shape: CursorShape,
+        cursor_color: [f32; 4],
     ) {
         self.instances.clear();
         let needed = cells.len().saturating_sub(self.instances.capacity());
@@ -189,9 +198,26 @@ impl BackgroundPipeline {
             };
             InstanceRaw {
                 pos: [cell.col as u32, cell.row as u32],
+                rect_offset: [0.0, 0.0],
+                rect_size: [1.0, 1.0],
                 color: bg,
             }
         }));
+
+        if let Some(pos) = cursor {
+            let (rect_offset, rect_size) = match cursor_shape {
+                CursorShape::Block => ([0.0, 0.0], [1.0, 1.0]),
+                CursorShape::Bar => ([0.0, 0.0], [0.15, 1.0]),
+                CursorShape::Underline => ([0.0, 0.85], [1.0, 0.15]),
+            };
+            self.instances.push(InstanceRaw {
+                pos,
+                rect_offset,
+                rect_size,
+                color: cursor_color,
+            });
+        }
+
         let required = self.instances.len().max(1);
 
         if required > self.instance_capacity {
@@ -217,10 +243,18 @@ impl BackgroundPipeline {
                 0,
                 bytemuck::cast_slice(&[InstanceRaw {
                     pos: [0, 0],
+                    rect_offset: [0.0, 0.0],
+                    rect_size: [1.0, 1.0],
                     color: [0.0, 0.0, 0.0, 0.0],
                 }]),
             );
         }
+    }
+
+    /// Number of background instances queued by the last `prepare_instances`
+    /// call (cells plus an optional cursor instance).
+    pub(super) fn instance_count(&self) -> usize {
+        self.instances.len()
     }
 
     pub(super) fn pipeline(&self) -> &wgpu::RenderPipeline {

--- a/src/gui/render/mod.rs
+++ b/src/gui/render/mod.rs
@@ -27,6 +27,10 @@ pub struct TerminalProgram {
     pub selection: Option<Selection>,
     pub mouse_mode: bool,
     pub display_offset: usize,
+    pub cursor: Option<[u32; 2]>,
+    pub cursor_shape: crate::config::CursorShape,
+    pub cursor_visible: bool,
+    pub cursor_color: [f32; 4],
 }
 
 impl TerminalProgram {
@@ -196,6 +200,10 @@ impl ShaderProgram<Message> for TerminalProgram {
             terminal_font_size: self.terminal_font_size,
             selection: self.selection,
             display_offset: self.display_offset,
+            cursor: self.cursor,
+            cursor_shape: self.cursor_shape,
+            cursor_visible: self.cursor_visible,
+            cursor_color: self.cursor_color,
         }
     }
 
@@ -226,6 +234,10 @@ pub struct TerminalPipeline {
     last_font_size: f32,
     last_selection: Option<Selection>,
     last_display_offset: usize,
+    last_cursor: Option<[u32; 2]>,
+    last_cursor_shape: crate::config::CursorShape,
+    last_cursor_visible: bool,
+    last_cursor_color: [f32; 4],
 }
 
 impl Pipeline for TerminalPipeline {
@@ -242,6 +254,10 @@ impl Pipeline for TerminalPipeline {
             last_font_size: 0.0,
             last_selection: None,
             last_display_offset: 0,
+            last_cursor: None,
+            last_cursor_shape: crate::config::CursorShape::Block,
+            last_cursor_visible: false,
+            last_cursor_color: [0.0; 4],
         }
     }
 }
@@ -257,6 +273,10 @@ pub struct TerminalPrimitive {
     terminal_font_size: f32,
     selection: Option<Selection>,
     display_offset: usize,
+    cursor: Option<[u32; 2]>,
+    cursor_shape: crate::config::CursorShape,
+    cursor_visible: bool,
+    cursor_color: [f32; 4],
 }
 
 impl Primitive for TerminalPrimitive {
@@ -291,7 +311,11 @@ impl Primitive for TerminalPrimitive {
             && offset == pipeline.last_offset
             && (font_size - pipeline.last_font_size).abs() < 0.01
             && self.selection == pipeline.last_selection
-            && self.display_offset == pipeline.last_display_offset;
+            && self.display_offset == pipeline.last_display_offset
+            && self.cursor == pipeline.last_cursor
+            && self.cursor_shape == pipeline.last_cursor_shape
+            && self.cursor_visible == pipeline.last_cursor_visible
+            && self.cursor_color == pipeline.last_cursor_color;
 
         if unchanged {
             return;
@@ -305,8 +329,15 @@ impl Primitive for TerminalPrimitive {
         pipeline.last_font_size = font_size;
         pipeline.last_selection = self.selection;
         pipeline.last_display_offset = self.display_offset;
+        pipeline.last_cursor = self.cursor;
+        pipeline.last_cursor_shape = self.cursor_shape;
+        pipeline.last_cursor_visible = self.cursor_visible;
+        pipeline.last_cursor_color = self.cursor_color;
 
         let cells = self.cells.as_slice();
+
+        // Cursor is only drawn when visible (blink "on" phase).
+        let active_cursor = self.cursor.filter(|_| self.cursor_visible);
 
         pipeline
             .bg
@@ -317,6 +348,9 @@ impl Primitive for TerminalPrimitive {
             cells,
             self.selection.as_ref(),
             self.display_offset,
+            active_cursor,
+            self.cursor_shape,
+            self.cursor_color,
         );
 
         pipeline
@@ -331,6 +365,8 @@ impl Primitive for TerminalPrimitive {
             cell_size,
             self.selection.as_ref(),
             self.display_offset,
+            active_cursor.filter(|_| self.cursor_shape == crate::config::CursorShape::Block),
+            self.cursor_color,
         );
     }
 
@@ -385,7 +421,7 @@ impl Primitive for TerminalPrimitive {
             offscreen_pass.set_vertex_buffer(0, bg_pipeline.quad_buffer().slice(..));
             offscreen_pass.set_vertex_buffer(1, bg_pipeline.instance_buffer().slice(..));
 
-            let instance_count = self.cells.len().max(1) as u32;
+            let instance_count = bg_pipeline.instance_count().max(1) as u32;
             offscreen_pass.draw(0..6, 0..instance_count);
 
             if text_pipeline.instance_len() > 0 {

--- a/src/gui/render/shaders/terminal.wgsl
+++ b/src/gui/render/shaders/terminal.wgsl
@@ -8,9 +8,11 @@ struct Uniforms {
 var<uniform> uniforms : Uniforms;
 
 struct VertexIn {
-    @location(0) quad_pos : vec2<f32>,
-    @location(1) cell_pos : vec2<u32>,
-    @location(2) color    : vec4<f32>,
+    @location(0) quad_pos    : vec2<f32>,
+    @location(1) cell_pos    : vec2<u32>,
+    @location(2) rect_offset : vec2<f32>,
+    @location(3) rect_size   : vec2<f32>,
+    @location(4) color       : vec4<f32>,
 };
 
 struct VertexOut {
@@ -21,7 +23,8 @@ struct VertexOut {
 @vertex
 fn vs_main(input : VertexIn) -> VertexOut {
     let cell = vec2<f32>(input.cell_pos);
-    let pixel = (cell + input.quad_pos) * uniforms.cell_size + uniforms.offset;
+    let pixel = (cell + input.rect_offset + input.quad_pos * input.rect_size)
+        * uniforms.cell_size + uniforms.offset;
 
     // Convert to NDC (origin top-left)
     let ndc = vec2<f32>(

--- a/src/gui/render/text/mod.rs
+++ b/src/gui/render/text/mod.rs
@@ -294,6 +294,7 @@ impl TextPipelineData {
         queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn prepare_instances(
         &mut self,
         device: &wgpu::Device,
@@ -302,7 +303,20 @@ impl TextPipelineData {
         cell_size: [f32; 2],
         selection: Option<&crate::terminal::Selection>,
         display_offset: usize,
+        cursor: Option<[u32; 2]>,
+        cursor_color: [f32; 4],
     ) {
+        // Color for a glyph sitting under an opaque block cursor: contrast
+        // against the cursor color (mirrors the legacy engine-side logic).
+        let cursor_glyph_color = {
+            let luma =
+                0.2126 * cursor_color[0] + 0.7152 * cursor_color[1] + 0.0722 * cursor_color[2];
+            if luma > 0.5 {
+                [0.0, 0.0, 0.0, 1.0]
+            } else {
+                [1.0, 1.0, 1.0, 1.0]
+            }
+        };
         let cell_width = cell_size[0];
         let cell_height = cell_size[1];
 
@@ -353,12 +367,17 @@ impl TextPipelineData {
                 } else {
                     cell.bg
                 };
+            let color = if cursor == Some([cell.col as u32, cell.row as u32]) {
+                cursor_glyph_color
+            } else {
+                cell.fg
+            };
             self.glyph_instances.push(GlyphInstance {
                 pos,
                 size: info.size,
                 uv_min: info.uv_min,
                 uv_max: info.uv_max,
-                color: cell.fg,
+                color,
                 bg_color,
             });
         }

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -1,4 +1,6 @@
-use crate::config::{AppConfig, AppConfigUpdates, SshAuthMethod, SshProfile, parse_hex_color};
+use crate::config::{
+    AppConfig, AppConfigUpdates, CursorShape, SshAuthMethod, SshProfile, parse_hex_color,
+};
 use crate::gui::app::Message;
 use crate::gui::theme::{Palette, RADIUS_NORMAL, RADIUS_SMALL, SPACING_NORMAL};
 use iced::widget::{column, container, row, rule, text, text_input, toggler};
@@ -217,6 +219,8 @@ pub struct SettingsDraft {
     pub terminal_scroll_speed: String,
     pub bracketed_paste: bool,
     pub multiline_paste_confirm: bool,
+    pub cursor_shape: CursorShape,
+    pub cursor_blink: bool,
     pub color_scheme: String,
     pub foreground: String,
     pub background: String,
@@ -254,6 +258,8 @@ impl SettingsDraft {
             terminal_scroll_speed: format!("{:.1}", config.terminal.scroll_multiplier),
             bracketed_paste: config.terminal.bracketed_paste,
             multiline_paste_confirm: config.terminal.multiline_paste_confirm,
+            cursor_shape: config.terminal.cursor_shape,
+            cursor_blink: config.terminal.cursor_blink,
             color_scheme: config.theme.color_scheme.clone(),
             foreground: format_rgb(config.theme.foreground),
             background: format_rgb(config.theme.background),
@@ -466,6 +472,8 @@ impl SettingsDraft {
             terminal_scroll_multiplier: parse_f32(&self.terminal_scroll_speed),
             terminal_bracketed_paste: Some(self.bracketed_paste),
             terminal_multiline_paste_confirm: Some(self.multiline_paste_confirm),
+            terminal_cursor_shape: Some(self.cursor_shape),
+            terminal_cursor_blink: Some(self.cursor_blink),
             color_scheme: Some(self.color_scheme.clone()),
             foreground: parse_hex_color(&self.foreground),
             background: parse_hex_color(&self.background),

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -1,10 +1,10 @@
-use crate::config::AppConfig;
+use crate::config::{AppConfig, CursorShape};
 use crate::gui::app::Message;
 use crate::gui::settings::{
     SettingsDraft, SettingsField, TerminalFontOption, hint_text, input_row_with_suffix, section,
 };
 use crate::gui::theme::{Palette, SPACING_NORMAL};
-use iced::widget::{checkbox, column, combo_box, row, text, toggler};
+use iced::widget::{checkbox, column, combo_box, pick_list, row, text, toggler};
 use iced::{Alignment, Element, Length};
 
 pub fn view<'a>(
@@ -142,10 +142,44 @@ pub fn view<'a>(
         palette,
     );
 
+    let cursor_section = section(
+        "Cursor",
+        column(vec![
+            row![
+                text("Shape").size(13).width(label_width),
+                pick_list(
+                    CursorShape::ALL,
+                    Some(draft.cursor_shape),
+                    Message::SettingsCursorShapeSelected,
+                )
+                .text_size(13),
+            ]
+            .align_y(Alignment::Center)
+            .spacing(SPACING_NORMAL)
+            .width(Length::Fill)
+            .into(),
+            row![
+                text("Blink").size(13).width(label_width),
+                toggler(draft.cursor_blink)
+                    .on_toggle(Message::SettingsCursorBlinkToggled)
+                    .size(18),
+            ]
+            .align_y(Alignment::Center)
+            .spacing(SPACING_NORMAL)
+            .width(Length::Fill)
+            .into(),
+        ])
+        .spacing(SPACING_NORMAL)
+        .width(Length::Fill)
+        .into(),
+        palette,
+    );
+
     column(vec![
         font_section,
         padding_section,
         scrollback_section,
+        cursor_section,
         paste_section,
     ])
     .spacing(SPACING_NORMAL)

--- a/src/gui/tab.rs
+++ b/src/gui/tab.rs
@@ -130,6 +130,14 @@ impl TerminalTab {
         self.engine.cursor_position()
     }
 
+    pub fn cursor_cell(&self) -> Option<(usize, usize)> {
+        self.engine.cursor_cell()
+    }
+
+    pub fn cursor_color(&self) -> [f32; 4] {
+        self.engine.cursor_color()
+    }
+
     pub fn selected_text(&self) -> Option<String> {
         let sel = self.selection.as_ref().filter(|s| !s.is_empty())?;
         let cells = self.engine.render_cells();

--- a/src/terminal/engine.rs
+++ b/src/terminal/engine.rs
@@ -153,11 +153,37 @@ impl TerminalEngine {
         (point.column.0, point.line.0.max(0) as usize)
     }
 
+    /// The renderable cursor cell as `(col, row)`, or `None` when the cursor is
+    /// hidden or the viewport is scrolled away from the latest output.
+    pub fn cursor_cell(&self) -> Option<(usize, usize)> {
+        let RenderableContent {
+            display_offset,
+            cursor,
+            ..
+        } = self.term.renderable_content();
+
+        if cursor.shape == CursorShape::Hidden || display_offset != 0 {
+            return None;
+        }
+
+        let col = cursor.point.column.0;
+        let row = cursor.point.line.0 as usize;
+        if row < self.size.lines && col < self.size.columns {
+            Some((col, row))
+        } else {
+            None
+        }
+    }
+
+    /// The theme cursor color as linear RGBA (opaque).
+    pub fn cursor_color(&self) -> [f32; 4] {
+        rgb_to_rgba(self.theme.cursor_rgb(), 1.0)
+    }
+
     fn build_cells_into(&self, cells: &mut Vec<CellVisual>) {
         let RenderableContent {
             display_iter,
             display_offset,
-            cursor,
             colors,
             ..
         } = self.term.renderable_content();
@@ -239,33 +265,6 @@ impl TerminalEngine {
                     slot.bg = bg;
                     slot.underline = indexed.cell.flags.intersects(Flags::ALL_UNDERLINES);
                     slot.wide = indexed.cell.flags.contains(Flags::WIDE_CHAR);
-                }
-            }
-        }
-
-        if cursor.shape != CursorShape::Hidden && display_offset == 0 {
-            let cursor_col = cursor.point.column.0;
-            let cursor_line = cursor.point.line.0 as usize;
-
-            if cursor_line < self.size.lines && cursor_col < self.size.columns {
-                let slot = &mut cells[idx(cursor_line, cursor_col, self.size.columns)];
-                let fg = slot.fg;
-                let bg = slot.bg;
-
-                if bg[3] > 0.0 {
-                    slot.fg = bg;
-                    slot.bg = fg;
-                } else {
-                    let luma = 0.2126 * fg[0] + 0.7152 * fg[1] + 0.0722 * fg[2];
-                    let cursor_fg = if luma > 0.5 {
-                        [0.0, 0.0, 0.0, 1.0]
-                    } else {
-                        [1.0, 1.0, 1.0, 1.0]
-                    };
-                    let mut cursor_bg = fg;
-                    cursor_bg[3] = 1.0;
-                    slot.fg = cursor_fg;
-                    slot.bg = cursor_bg;
                 }
             }
         }

--- a/src/terminal/theme.rs
+++ b/src/terminal/theme.rs
@@ -391,6 +391,11 @@ impl TerminalTheme {
         }
     }
 
+    /// The configured cursor color.
+    pub(super) fn cursor_rgb(&self) -> Rgb {
+        self.cursor
+    }
+
     pub(super) fn named_color(&self, named: NamedColor) -> Rgb {
         match named {
             NamedColor::Foreground | NamedColor::BrightForeground => self.foreground,


### PR DESCRIPTION
Closes #133. Epic #126.

커서 모양(Block/Bar/Underline)과 깜빡임 on/off를 설정으로 노출합니다.

## 변경
- `config`: `CursorShape` enum + `cursor_shape`/`cursor_blink` 설정 추가 (기본 Block/on)
- 커서 렌더링을 엔진에서 렌더러로 이동 — 엔진 셀은 순수 콘텐츠만 담음
- bg 파이프라인에 셀 내부 부분 사각형(`rect_offset`/`rect_size`) 지원 → Bar/Underline 커서 렌더
- Block 커서 아래 글리프는 커서 색 대비로 자동 보정
- 530ms 깜빡임 subscription (설정 off 시 항상 표시)
- 설정 > 터미널에 "Cursor" 섹션 추가 (모양 선택 + 깜빡임 토글)

build / clippy / test(--lib) 모두 통과.