### PR TITLE
feat: configurable terminal bell behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ windows = { version = "0.62", default-features = false, features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Shell",
     "Win32_Graphics_Gdi",
+    "Win32_System_Diagnostics_Debug",
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,31 @@ impl std::fmt::Display for CursorShape {
     }
 }
 
+/// Behavior when the terminal receives a bell (`\a`, 0x07).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BellMode {
+    Off,
+    #[default]
+    Visual,
+    Sound,
+}
+
+impl BellMode {
+    pub const ALL: [Self; 3] = [Self::Off, Self::Visual, Self::Sound];
+}
+
+impl std::fmt::Display for BellMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::Off => "Off",
+            Self::Visual => "Visual flash",
+            Self::Sound => "Sound",
+        };
+        f.write_str(label)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SshProfile {
     pub name: String,
@@ -164,6 +189,7 @@ pub struct TerminalConfig {
     pub scroll_multiplier: f32,
     pub cursor_shape: CursorShape,
     pub cursor_blink: bool,
+    pub bell_mode: BellMode,
 }
 
 #[derive(Debug, Clone)]
@@ -235,6 +261,7 @@ struct TerminalFileConfig {
     scroll_multiplier: Option<f32>,
     cursor_shape: Option<CursorShape>,
     cursor_blink: Option<bool>,
+    bell_mode: Option<BellMode>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -297,6 +324,7 @@ pub struct AppConfigUpdates {
     pub terminal_scroll_multiplier: Option<f32>,
     pub terminal_cursor_shape: Option<CursorShape>,
     pub terminal_cursor_blink: Option<bool>,
+    pub terminal_bell_mode: Option<BellMode>,
 }
 
 impl Default for AppConfig {
@@ -321,6 +349,7 @@ impl Default for AppConfig {
                 scroll_multiplier: DEFAULT_TERMINAL_SCROLL_MULTIPLIER,
                 cursor_shape: CursorShape::default(),
                 cursor_blink: DEFAULT_CURSOR_BLINK,
+                bell_mode: BellMode::default(),
             },
             theme: ThemeConfig {
                 color_scheme: "Catppuccin Mocha".to_string(),
@@ -414,6 +443,9 @@ impl AppConfig {
         }
         if let Some(enabled) = updates.terminal_cursor_blink {
             self.terminal.cursor_blink = enabled;
+        }
+        if let Some(mode) = updates.terminal_bell_mode {
+            self.terminal.bell_mode = mode;
         }
         if let Some(scheme) = updates.color_scheme {
             self.theme.color_scheme = scheme;
@@ -547,6 +579,9 @@ impl AppConfig {
             }
             if let Some(enabled) = term.cursor_blink {
                 self.terminal.cursor_blink = enabled;
+            }
+            if let Some(mode) = term.bell_mode {
+                self.terminal.bell_mode = mode;
             }
         }
 
@@ -894,6 +929,7 @@ impl From<&AppConfig> for FileConfig {
                 scroll_multiplier: Some(config.terminal.scroll_multiplier),
                 cursor_shape: Some(config.terminal.cursor_shape),
                 cursor_blink: Some(config.terminal.cursor_blink),
+                bell_mode: Some(config.terminal.bell_mode),
             }),
             theme: Some(ThemeFileConfig {
                 color_scheme: if config.theme.color_scheme.is_empty() {

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -39,6 +39,7 @@ pub enum Message {
     SettingsMultilinePasteConfirmToggled(bool),
     SettingsCursorShapeSelected(crate::config::CursorShape),
     SettingsCursorBlinkToggled(bool),
+    SettingsBellModeSelected(crate::config::BellMode),
     AddSshProfile,
     EditSshProfile(usize),
     RequestRemoveSshProfile(usize),
@@ -207,7 +208,12 @@ pub struct App {
     pub(super) pending_paste: Option<String>,
     /// Current on/off phase of the blinking cursor.
     pub(super) cursor_blink_on: bool,
+    /// Start time of an active visual bell flash, if any.
+    pub(super) bell_flash_start: Option<std::time::Instant>,
 }
+
+/// Duration of the visual bell flash overlay.
+pub(super) const BELL_FLASH_DURATION: std::time::Duration = std::time::Duration::from_millis(150);
 
 #[derive(Debug, Clone)]
 pub struct PasswordPromptState {
@@ -292,6 +298,7 @@ impl App {
             password_prompt: None,
             pending_paste: None,
             cursor_blink_on: true,
+            bell_flash_start: None,
         }
     }
 

--- a/src/gui/app/subscription.rs
+++ b/src/gui/app/subscription.rs
@@ -10,8 +10,12 @@ use iced::{Event, Subscription, event, keyboard, mouse, time, window};
 impl App {
     pub fn subscription(&self) -> Subscription<Message> {
         let now = Instant::now();
+        let bell_flashing = self
+            .bell_flash_start
+            .is_some_and(|start| start.elapsed() < super::BELL_FLASH_DURATION);
         let has_animation = self.shell_picker_anim.is_animating(now)
-            || self.tabs.iter().any(|tab| tab.sftp.anim.is_animating(now));
+            || self.tabs.iter().any(|tab| tab.sftp.anim.is_animating(now))
+            || bell_flashing;
 
         let animation_tick = if has_animation {
             time::every(std::time::Duration::from_millis(16)).map(|_| Message::AnimationTick)

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -464,6 +464,10 @@ impl App {
                 self.settings_draft.cursor_blink = enabled;
                 return self.apply_settings(true);
             }
+            Message::SettingsBellModeSelected(mode) => {
+                self.settings_draft.bell_mode = mode;
+                return self.apply_settings(true);
+            }
             Message::FontSelected(option) => {
                 self.settings_draft
                     .update(SettingsField::TerminalFontSelection, option.value);
@@ -657,6 +661,11 @@ impl App {
                     if !tab.sftp.anim.is_animating(now) && !tab.sftp.anim.value() {
                         tab.sftp.open = false;
                     }
+                }
+                if let Some(start) = self.bell_flash_start
+                    && start.elapsed() >= super::BELL_FLASH_DURATION
+                {
+                    self.bell_flash_start = None;
                 }
             }
             Message::CursorBlink => {

--- a/src/gui/app/update/terminal.rs
+++ b/src/gui/app/update/terminal.rs
@@ -1,6 +1,6 @@
 use super::super::{App, Message, SETTINGS_TAB_INDEX};
 use super::{TAB_BAR_SCROLLABLE_ID, TERMINAL_SCROLLABLE_ID};
-use crate::config::AppConfigUpdates;
+use crate::config::{AppConfigUpdates, BellMode};
 use crate::session::OutputEvent;
 use iced::widget::operation::{scroll_to, snap_to};
 use iced::widget::scrollable;
@@ -11,7 +11,10 @@ impl App {
         match event {
             OutputEvent::Data { tab_id, bytes } => {
                 if let Some(tab) = self.tabs.iter_mut().find(|t| t.id == tab_id) {
-                    tab.feed_bytes(&bytes);
+                    let bell = tab.feed_bytes(&bytes);
+                    if bell {
+                        self.handle_bell(tab_id);
+                    }
                 }
             }
             OutputEvent::Closed { tab_id } => {
@@ -20,6 +23,25 @@ impl App {
                     if self.active_tab >= self.tabs.len() && !self.tabs.is_empty() {
                         self.active_tab = self.tabs.len() - 1;
                     }
+                }
+            }
+        }
+    }
+
+    /// Reacts to a terminal bell from the tab identified by `tab_id`,
+    /// according to the configured bell mode.
+    fn handle_bell(&mut self, tab_id: u64) {
+        match self.config.terminal.bell_mode {
+            BellMode::Off => {}
+            BellMode::Sound => crate::platform::ring_bell(),
+            BellMode::Visual => {
+                let is_active = self.active_tab != SETTINGS_TAB_INDEX
+                    && self
+                        .tabs
+                        .get(self.active_tab)
+                        .is_some_and(|t| t.id == tab_id);
+                if is_active {
+                    self.bell_flash_start = Some(std::time::Instant::now());
                 }
             }
         }

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -239,6 +239,33 @@ impl App {
             terminal_view
         };
 
+        // Visual bell: a translucent flash that fades out over its duration.
+        let with_flash: Element<Message> = if let Some(progress) = self
+            .bell_flash_start
+            .map(|start| start.elapsed())
+            .filter(|elapsed| *elapsed < super::BELL_FLASH_DURATION)
+            .map(|elapsed| elapsed.as_secs_f32() / super::BELL_FLASH_DURATION.as_secs_f32())
+        {
+            let alpha = 0.5 * (1.0 - progress).clamp(0.0, 1.0);
+            let flash_color = Color {
+                a: alpha,
+                ..self.theme_text_color()
+            };
+            let flash = container("")
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .style(move |_theme: &iced::Theme| container::Style {
+                    background: Some(Background::Color(flash_color)),
+                    ..Default::default()
+                });
+            stack![with_drawer, flash]
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()
+        } else {
+            with_drawer
+        };
+
         let (cursor_col, cursor_row) = active_tab.cursor_position();
         let cursor_cell = crate::gui::components::ime_wrapper::CursorCell {
             col: cursor_col,
@@ -251,7 +278,7 @@ impl App {
             ],
         };
 
-        ImeEnabled::new(with_drawer)
+        ImeEnabled::new(with_flash)
             .preedit(self.ime_preedit.clone())
             .cursor_cell(Some(cursor_cell))
             .text_size(self.config.terminal.font_size)

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -1,5 +1,5 @@
 use crate::config::{
-    AppConfig, AppConfigUpdates, CursorShape, SshAuthMethod, SshProfile, parse_hex_color,
+    AppConfig, AppConfigUpdates, BellMode, CursorShape, SshAuthMethod, SshProfile, parse_hex_color,
 };
 use crate::gui::app::Message;
 use crate::gui::theme::{Palette, RADIUS_NORMAL, RADIUS_SMALL, SPACING_NORMAL};
@@ -221,6 +221,7 @@ pub struct SettingsDraft {
     pub multiline_paste_confirm: bool,
     pub cursor_shape: CursorShape,
     pub cursor_blink: bool,
+    pub bell_mode: BellMode,
     pub color_scheme: String,
     pub foreground: String,
     pub background: String,
@@ -260,6 +261,7 @@ impl SettingsDraft {
             multiline_paste_confirm: config.terminal.multiline_paste_confirm,
             cursor_shape: config.terminal.cursor_shape,
             cursor_blink: config.terminal.cursor_blink,
+            bell_mode: config.terminal.bell_mode,
             color_scheme: config.theme.color_scheme.clone(),
             foreground: format_rgb(config.theme.foreground),
             background: format_rgb(config.theme.background),
@@ -474,6 +476,7 @@ impl SettingsDraft {
             terminal_multiline_paste_confirm: Some(self.multiline_paste_confirm),
             terminal_cursor_shape: Some(self.cursor_shape),
             terminal_cursor_blink: Some(self.cursor_blink),
+            terminal_bell_mode: Some(self.bell_mode),
             color_scheme: Some(self.color_scheme.clone()),
             foreground: parse_hex_color(&self.foreground),
             background: parse_hex_color(&self.background),

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -1,4 +1,4 @@
-use crate::config::{AppConfig, CursorShape};
+use crate::config::{AppConfig, BellMode, CursorShape};
 use crate::gui::app::Message;
 use crate::gui::settings::{
     SettingsDraft, SettingsField, TerminalFontOption, hint_text, input_row_with_suffix, section,
@@ -175,11 +175,35 @@ pub fn view<'a>(
         palette,
     );
 
+    let bell_section = section(
+        "Bell",
+        column(vec![
+            row![
+                text("Behavior").size(13).width(label_width),
+                pick_list(
+                    BellMode::ALL,
+                    Some(draft.bell_mode),
+                    Message::SettingsBellModeSelected,
+                )
+                .text_size(13),
+            ]
+            .align_y(Alignment::Center)
+            .spacing(SPACING_NORMAL)
+            .width(Length::Fill)
+            .into(),
+        ])
+        .spacing(SPACING_NORMAL)
+        .width(Length::Fill)
+        .into(),
+        palette,
+    );
+
     column(vec![
         font_section,
         padding_section,
         scrollback_section,
         cursor_section,
+        bell_section,
         paste_section,
     ])
     .spacing(SPACING_NORMAL)

--- a/src/gui/tab.rs
+++ b/src/gui/tab.rs
@@ -98,11 +98,13 @@ impl TerminalTab {
         }
     }
 
-    pub fn feed_bytes(&mut self, bytes: &[u8]) {
+    /// Feeds PTY bytes to the terminal engine. Returns `true` if a bell rang.
+    pub fn feed_bytes(&mut self, bytes: &[u8]) -> bool {
         self.engine.feed_bytes(bytes);
         if let Some(new_title) = self.engine.take_title() {
             self.title = new_title;
         }
+        self.engine.take_bell()
     }
 
     pub fn render_cells(&self) -> std::sync::Arc<Vec<CellVisual>> {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -20,6 +20,11 @@ pub fn apply_style(handle: WindowHandle<'_>, theme: &ThemeConfig) {
     apply_style_inner(handle, theme);
 }
 
+/// Play the macOS system beep.
+pub fn ring_bell() {
+    objc2_app_kit::NSBeep();
+}
+
 const APP_ICON_PNG: &[u8] = include_bytes!("../../assets/logo.png");
 
 pub fn set_app_icon_once() {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -21,3 +21,9 @@ pub fn apply_style(
 ) {
     // No-op on other platforms
 }
+
+/// Play the system beep. No-op on platforms without a system sound API.
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+pub fn ring_bell() {
+    // No-op on other platforms
+}

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -139,3 +139,13 @@ pub fn apply_style(
         }
     }
 }
+
+/// Play the Windows system beep (default `MB_OK` sound).
+pub fn ring_bell() {
+    use windows::Win32::System::Diagnostics::Debug::MessageBeep;
+    use windows::Win32::UI::WindowsAndMessaging::MB_OK;
+
+    unsafe {
+        let _ = MessageBeep(MB_OK);
+    }
+}

--- a/src/terminal/engine.rs
+++ b/src/terminal/engine.rs
@@ -10,6 +10,7 @@ use alacritty_terminal::term::{
 use alacritty_terminal::vte::ansi::{CursorShape, Processor};
 use std::cell::{Cell, RefCell};
 use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 pub struct TerminalEngine {
@@ -21,6 +22,7 @@ pub struct TerminalEngine {
     cache_dirty: Cell<bool>,
     cache_size: Cell<TerminalSize>,
     title: Arc<Mutex<Option<String>>>,
+    bell_pending: Arc<AtomicBool>,
 }
 
 impl TerminalEngine {
@@ -35,6 +37,7 @@ impl TerminalEngine {
             ..Default::default()
         };
         let title: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let bell_pending: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let term = Term::new(
             config,
             &size,
@@ -42,6 +45,7 @@ impl TerminalEngine {
                 writer: Arc::clone(&writer),
                 size,
                 title: Arc::clone(&title),
+                bell_pending: Arc::clone(&bell_pending),
             },
         );
 
@@ -54,6 +58,7 @@ impl TerminalEngine {
             cache_dirty: Cell::new(true),
             cache_size: Cell::new(size),
             title,
+            bell_pending,
         }
     }
 
@@ -63,6 +68,11 @@ impl TerminalEngine {
 
     pub fn take_title(&self) -> Option<String> {
         self.title.lock().ok()?.take()
+    }
+
+    /// Returns true once if a bell rang since the last call.
+    pub fn take_bell(&self) -> bool {
+        self.bell_pending.swap(false, Ordering::Relaxed)
     }
 
     pub fn feed_bytes(&mut self, bytes: &[u8]) {
@@ -276,6 +286,7 @@ struct PtyEventProxy {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     size: TerminalSize,
     title: Arc<Mutex<Option<String>>>,
+    bell_pending: Arc<AtomicBool>,
 }
 
 impl EventListener for PtyEventProxy {
@@ -304,6 +315,9 @@ impl EventListener for PtyEventProxy {
                 if let Ok(mut guard) = self.title.lock() {
                     *guard = Some(new_title);
                 }
+            }
+            Event::Bell => {
+                self.bell_pending.store(true, Ordering::Relaxed);
             }
             _ => {}
         }


### PR DESCRIPTION
Closes #134. Epic #126.

벨(`\a`) 수신 시 동작을 설정으로 노출합니다 — Off / Visual flash / Sound (기본 Visual).

## 변경
- alacritty `Event::Bell`을 캡처 (현재는 버려지고 있었음) — 엔진의 `AtomicBool` 플래그 → `feed_bytes` 반환값으로 App에 전파
- `config`: `BellMode` enum + `bell_mode` 설정 plumbing
- 시스템 비프: 의존성 추가 없이 플랫폼 API 사용 (macOS `NSBeep`, Windows `MessageBeep`, Linux no-op)
- 시각적 플래시: 터미널 위에 150ms 페이드아웃 반투명 오버레이
- 설정 > 터미널에 "Bell" 섹션 추가

build / clippy / test(--lib) / fmt 모두 통과 (macOS 로컬). Windows/Linux 경로는 cfg-gated — CI에서 확인.