### PR TITLE
feat: animated hover transitions with on/off setting

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -31,6 +31,10 @@ ssh = "SSH"
 section_title = "Language"
 auto = "Auto"
 
+[settings.appearance]
+animations_section = "Animations"
+animations = "Enable animations"
+
 [settings.terminal]
 font_section = "Font"
 size = "Size"

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -31,6 +31,10 @@ ssh = "SSH"
 section_title = "언어"
 auto = "자동"
 
+[settings.appearance]
+animations_section = "애니메이션"
+animations = "애니메이션 사용"
+
 [settings.terminal]
 font_section = "글꼴"
 size = "크기"

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,7 @@ pub const DEFAULT_BRACKETED_PASTE: bool = true;
 pub const DEFAULT_MULTILINE_PASTE_CONFIRM: bool = false;
 pub const DEFAULT_TERMINAL_SCROLL_MULTIPLIER: f32 = 1.0;
 pub const DEFAULT_CURSOR_BLINK: bool = true;
+pub const DEFAULT_ANIMATIONS_ENABLED: bool = true;
 const DEJAVU_SANS_MONO: &[u8] = include_bytes!("../fonts/DejaVuSansMono.ttf");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
@@ -173,6 +174,8 @@ pub struct UiConfig {
     pub window_height: f32,
     /// `None` = follow `LANG` env; otherwise a tag from `AVAILABLE_LOCALES`.
     pub language: Option<String>,
+    /// Whether smooth hover transition animations are enabled.
+    pub animations_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -243,6 +246,7 @@ struct UiFileConfig {
     window_width: Option<f32>,
     window_height: Option<f32>,
     language: Option<String>,
+    animations_enabled: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -296,6 +300,7 @@ pub struct AppConfigUpdates {
     pub window_height: Option<f32>,
     /// `None` = no change; `Some("auto"|"")` = clear; `Some("<tag>")` = set.
     pub language: Option<String>,
+    pub animations_enabled: Option<bool>,
     pub terminal_font_selection: Option<String>,
     pub terminal_font_size: Option<f32>,
     pub terminal_padding_x: Option<f32>,
@@ -335,6 +340,7 @@ impl Default for AppConfig {
                 window_width: DEFAULT_WINDOW_WIDTH,
                 window_height: DEFAULT_WINDOW_HEIGHT,
                 language: None,
+                animations_enabled: DEFAULT_ANIMATIONS_ENABLED,
             },
             terminal: TerminalConfig {
                 cell_width,
@@ -401,6 +407,9 @@ impl AppConfig {
         }
         if let Some(lang) = updates.language.as_deref() {
             self.ui.language = sanitize_language(lang);
+        }
+        if let Some(enabled) = updates.animations_enabled {
+            self.ui.animations_enabled = enabled;
         }
         let old_font = self.terminal.font_selection.clone();
         if let Some(selection) = updates.terminal_font_selection {
@@ -532,6 +541,9 @@ impl AppConfig {
             }
             if let Some(lang) = ui.language.as_deref() {
                 self.ui.language = sanitize_language(lang);
+            }
+            if let Some(enabled) = ui.animations_enabled {
+                self.ui.animations_enabled = enabled;
             }
         }
 
@@ -914,6 +926,7 @@ impl From<&AppConfig> for FileConfig {
                 window_width: Some(config.ui.window_width),
                 window_height: Some(config.ui.window_height),
                 language: config.ui.language.clone(),
+                animations_enabled: Some(config.ui.animations_enabled),
             }),
             terminal: Some(TerminalFileConfig {
                 cell_width: None,

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -35,6 +35,7 @@ pub enum Message {
     SettingsInputChanged(SettingsField, String),
     SettingsInputCommitted(SettingsField, String),
     SettingsBlurToggled(bool),
+    SettingsAnimationsToggled(bool),
     SettingsBracketedPasteToggled(bool),
     SettingsMultilinePasteConfirmToggled(bool),
     SettingsCursorShapeSelected(crate::config::CursorShape),

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -448,6 +448,10 @@ impl App {
                 self.settings_draft.blur_enabled = enabled;
                 return self.apply_settings(true);
             }
+            Message::SettingsAnimationsToggled(enabled) => {
+                self.settings_draft.animations_enabled = enabled;
+                return self.apply_settings(true);
+            }
             Message::SettingsBracketedPasteToggled(enabled) => {
                 self.settings_draft.bracketed_paste = enabled;
                 return self.apply_settings(true);

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -61,6 +61,7 @@ impl App {
             self.dragging_tab,
             self.drag_target,
             palette,
+            self.config.ui.animations_enabled,
         );
 
         let main_content: Element<Message> = if self.active_tab == SETTINGS_TAB_INDEX {
@@ -344,36 +345,50 @@ impl App {
                 ]
                 .spacing(1);
 
+                // The hover background is painted by `hover_fade`; the button
+                // itself stays transparent.
+                let session_btn = button(label_col)
+                    .style(
+                        move |_theme: &iced::Theme, _status: iced::widget::button::Status| {
+                            iced::widget::button::Style {
+                                background: Some(Background::Color(Color::TRANSPARENT)),
+                                text_color: palette.text,
+                                border: Border {
+                                    radius: RADIUS_SMALL.into(),
+                                    width: 0.0,
+                                    color: Color::TRANSPARENT,
+                                },
+                                shadow: iced::Shadow::default(),
+                                snap: false,
+                            }
+                        },
+                    )
+                    .padding([6, 10])
+                    .width(Length::Fixed(240.0))
+                    .on_press(Message::LaunchFromHistory(i));
+
+                let rest = crate::gui::components::HoverStyle {
+                    background: Color::TRANSPARENT,
+                    border_color: Color::TRANSPARENT,
+                    border_width: 0.0,
+                    radius: RADIUS_SMALL,
+                };
+                let hover = crate::gui::components::HoverStyle {
+                    background: Color {
+                        a: 0.08,
+                        ..palette.text
+                    },
+                    ..rest
+                };
+
                 content.push(
-                    button(label_col)
-                        .style(
-                            move |_theme: &iced::Theme, status: iced::widget::button::Status| {
-                                let hovered =
-                                    matches!(status, iced::widget::button::Status::Hovered);
-                                iced::widget::button::Style {
-                                    background: Some(Background::Color(if hovered {
-                                        Color {
-                                            a: 0.08,
-                                            ..palette.text
-                                        }
-                                    } else {
-                                        Color::TRANSPARENT
-                                    })),
-                                    text_color: palette.text,
-                                    border: Border {
-                                        radius: RADIUS_SMALL.into(),
-                                        width: 0.0,
-                                        color: Color::TRANSPARENT,
-                                    },
-                                    shadow: iced::Shadow::default(),
-                                    snap: false,
-                                }
-                            },
-                        )
-                        .padding([6, 10])
-                        .width(Length::Fixed(240.0))
-                        .on_press(Message::LaunchFromHistory(i))
-                        .into(),
+                    crate::gui::components::hover_fade(
+                        session_btn,
+                        rest,
+                        hover,
+                        self.config.ui.animations_enabled,
+                    )
+                    .into(),
                 );
             }
         }

--- a/src/gui/app/view/settings.rs
+++ b/src/gui/app/view/settings.rs
@@ -7,44 +7,33 @@ use iced::{Background, Border, Color, Element, Length};
 impl App {
     pub(in crate::gui) fn view_settings(&self) -> Element<'_, Message> {
         let palette = self.palette;
+        let animations_enabled = self.config.ui.animations_enabled;
         let mut category_items: Vec<Element<Message>> = Vec::new();
 
         for category in SettingsCategory::ALL {
             let is_active = category == self.settings_category;
             let icon = category.icon();
             let label = category.label();
-            let button_style = move |_theme: &iced::Theme, status: iced::widget::button::Status| {
-                let bg = if is_active {
-                    Color {
-                        a: 0.12,
-                        ..palette.text
-                    }
-                } else {
-                    match status {
-                        iced::widget::button::Status::Hovered => Color {
-                            a: 0.08,
-                            ..palette.text
+            // The background is painted by `hover_fade` behind the button so
+            // it can cross-fade on hover; the button itself stays transparent.
+            let button_style =
+                move |_theme: &iced::Theme, _status: iced::widget::button::Status| {
+                    iced::widget::button::Style {
+                        background: Some(Background::Color(Color::TRANSPARENT)),
+                        text_color: if is_active {
+                            palette.text
+                        } else {
+                            palette.text_secondary
                         },
-                        _ => Color::TRANSPARENT,
+                        border: Border {
+                            radius: RADIUS_NORMAL.into(),
+                            width: 0.0,
+                            color: Color::TRANSPARENT,
+                        },
+                        shadow: iced::Shadow::default(),
+                        snap: true,
                     }
                 };
-
-                iced::widget::button::Style {
-                    background: Some(Background::Color(bg)),
-                    text_color: if is_active {
-                        palette.text
-                    } else {
-                        palette.text_secondary
-                    },
-                    border: Border {
-                        radius: RADIUS_NORMAL.into(),
-                        width: 0.0,
-                        color: Color::TRANSPARENT,
-                    },
-                    shadow: iced::Shadow::default(),
-                    snap: true,
-                }
-            };
 
             let btn_content = row![text(icon).size(14), text(label).size(13),]
                 .spacing(SPACING_SMALL)
@@ -55,7 +44,36 @@ impl App {
                 .width(Length::Fill)
                 .on_press(Message::SelectSettingsCategory(category))
                 .style(button_style);
-            category_items.push(item.into());
+
+            let rest = crate::gui::components::HoverStyle {
+                background: if is_active {
+                    Color {
+                        a: 0.12,
+                        ..palette.text
+                    }
+                } else {
+                    Color::TRANSPARENT
+                },
+                border_color: Color::TRANSPARENT,
+                border_width: 0.0,
+                radius: RADIUS_NORMAL,
+            };
+            // Active items keep their fixed background; inactive ones brighten.
+            let hover = if is_active {
+                rest
+            } else {
+                crate::gui::components::HoverStyle {
+                    background: Color {
+                        a: 0.08,
+                        ..palette.text
+                    },
+                    ..rest
+                }
+            };
+
+            category_items.push(
+                crate::gui::components::hover_fade(item, rest, hover, animations_enabled).into(),
+            );
         }
 
         let sidebar = container(

--- a/src/gui/components/hover_fade.rs
+++ b/src/gui/components/hover_fade.rs
@@ -1,0 +1,268 @@
+use iced::advanced::layout::{self, Layout};
+use iced::advanced::renderer;
+use iced::advanced::widget::tree::{self, Tree};
+use iced::advanced::widget::{Operation, Widget};
+use iced::advanced::{Clipboard, Shell};
+use iced::{
+    Animation, Background, Border, Color, Element, Event, Length, Rectangle, Size, Vector, mouse,
+};
+
+use std::time::{Duration, Instant};
+
+const TRANSITION: Duration = Duration::from_millis(120);
+
+/// Background + border appearance for one end of a hover transition.
+#[derive(Debug, Clone, Copy)]
+pub struct HoverStyle {
+    pub background: Color,
+    pub border_color: Color,
+    pub border_width: f32,
+    pub radius: f32,
+}
+
+/// Linearly interpolates between two colors.
+fn lerp_color(from: Color, to: Color, t: f32) -> Color {
+    Color {
+        r: from.r + (to.r - from.r) * t,
+        g: from.g + (to.g - from.g) * t,
+        b: from.b + (to.b - from.b) * t,
+        a: from.a + (to.a - from.a) * t,
+    }
+}
+
+/// Per-widget animation state held in the widget tree.
+struct State {
+    anim: Animation<bool>,
+}
+
+/// A widget that wraps a child `Element` and cross-fades a background +
+/// border between a "rest" and a "hovered" appearance as the cursor enters
+/// and leaves the widget bounds.
+///
+/// The wrapped child is fully delegated to for layout, events, drawing and
+/// overlays, so interactive children (such as buttons) keep working — the
+/// `HoverFade` only paints an animated quad *behind* the child.
+pub struct HoverFade<'a, Message, Theme, Renderer> {
+    content: Element<'a, Message, Theme, Renderer>,
+    rest: HoverStyle,
+    hover: HoverStyle,
+    enabled: bool,
+}
+
+/// Wraps `child` so its background + border smoothly fade on hover.
+///
+/// When `enabled` is `false` the transition is skipped entirely: the
+/// appearance snaps instantly between `rest` and `hover` with no redraw
+/// requests.
+pub fn hover_fade<'a, Message, Theme, Renderer>(
+    child: impl Into<Element<'a, Message, Theme, Renderer>>,
+    rest: HoverStyle,
+    hover: HoverStyle,
+    enabled: bool,
+) -> HoverFade<'a, Message, Theme, Renderer> {
+    HoverFade {
+        content: child.into(),
+        rest,
+        hover,
+        enabled,
+    }
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for HoverFade<'_, Message, Theme, Renderer>
+where
+    Renderer: iced::advanced::Renderer,
+{
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State {
+            anim: Animation::new(false)
+                .duration(TRANSITION)
+                .easing(iced::animation::Easing::EaseOut),
+        })
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.content)]
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_ref(&self.content));
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.content
+            .as_widget_mut()
+            .layout(&mut tree.children[0], renderer, limits)
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        self.content
+            .as_widget_mut()
+            .operate(&mut tree.children[0], layout, renderer, operation);
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_mut::<State>();
+        let now = Instant::now();
+        let hovered = cursor.is_over(layout.bounds());
+
+        if self.enabled {
+            if state.anim.value() != hovered {
+                state.anim.go_mut(hovered, now);
+            }
+            // Keep advancing the fade while it is in progress.
+            if matches!(
+                event,
+                Event::Window(iced::window::Event::RedrawRequested(_))
+            ) && state.anim.is_animating(now)
+            {
+                shell.request_redraw();
+            }
+        } else {
+            // Animations disabled: snap instantly, no redraw requests.
+            if state.anim.value() != hovered {
+                state.anim.go_mut(hovered, now - TRANSITION);
+            }
+        }
+
+        self.content.as_widget_mut().update(
+            &mut tree.children[0],
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        );
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_ref::<State>();
+        let bounds = layout.bounds();
+
+        let t: f32 = if self.enabled {
+            state.anim.interpolate(0.0, 1.0, Instant::now())
+        } else if state.anim.value() {
+            1.0
+        } else {
+            0.0
+        };
+
+        let background = lerp_color(self.rest.background, self.hover.background, t);
+        let border_color = lerp_color(self.rest.border_color, self.hover.border_color, t);
+        let border_width =
+            self.rest.border_width + (self.hover.border_width - self.rest.border_width) * t;
+        let radius = self.rest.radius + (self.hover.radius - self.rest.radius) * t;
+
+        if background.a > 0.0 || (border_width > 0.0 && border_color.a > 0.0) {
+            renderer.fill_quad(
+                renderer::Quad {
+                    bounds,
+                    border: Border {
+                        color: border_color,
+                        width: border_width,
+                        radius: radius.into(),
+                    },
+                    shadow: iced::Shadow::default(),
+                    snap: true,
+                },
+                Background::Color(background),
+            );
+        }
+
+        self.content.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            style,
+            layout,
+            cursor,
+            viewport,
+        );
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'b>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<iced::advanced::overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content.as_widget_mut().overlay(
+            &mut tree.children[0],
+            layout,
+            renderer,
+            viewport,
+            translation,
+        )
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<HoverFade<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: 'a,
+    Theme: 'a,
+    Renderer: iced::advanced::Renderer + 'a,
+{
+    fn from(widget: HoverFade<'a, Message, Theme, Renderer>) -> Self {
+        Element::new(widget)
+    }
+}

--- a/src/gui/components/mod.rs
+++ b/src/gui/components/mod.rs
@@ -1,6 +1,7 @@
 pub mod button;
 pub mod container;
 pub mod context_menu;
+pub mod hover_fade;
 pub mod ime_wrapper;
 pub mod tab_bar;
 
@@ -21,4 +22,5 @@ pub fn button_secondary(
 }
 
 pub use container::panel;
+pub use hover_fade::{HoverStyle, hover_fade};
 pub use tab_bar::tab_bar;

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -1,4 +1,5 @@
 use crate::gui::app::Message;
+use crate::gui::components::{HoverStyle, hover_fade};
 use crate::gui::theme::Palette;
 use iced::widget::mouse_area;
 use iced::widget::{button, container, row, scrollable, text};
@@ -15,6 +16,7 @@ pub fn tab_bar<'a>(
     dragging_tab: Option<usize>,
     drag_target: Option<usize>,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let mut tab_elements: Vec<Element<Message>> = Vec::new();
     let is_reordering =
@@ -41,7 +43,14 @@ pub fn tab_bar<'a>(
             tab_elements.push(gap.into());
         }
 
-        let tab_item = browser_tab(title, index, is_active, tab_alpha, palette);
+        let tab_item = browser_tab(
+            title,
+            index,
+            is_active,
+            tab_alpha,
+            palette,
+            animations_enabled,
+        );
         let is_terminal_tab = index != crate::gui::app::SETTINGS_TAB_INDEX;
         let mut tab_item = mouse_area(tab_item)
             .on_press(Message::TabSelected(index))
@@ -235,6 +244,7 @@ fn browser_tab<'a>(
     is_active: bool,
     tab_alpha: f32,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     const MAX_TITLE_LEN: usize = 24;
     let display_title: std::borrow::Cow<'a, str> = if title.chars().count() > MAX_TITLE_LEN {
@@ -288,14 +298,13 @@ fn browser_tab<'a>(
         .align_y(iced::Alignment::Center);
 
     let inactive_alpha = tab_alpha.clamp(0.0, 1.0);
-    let tab_button = button(tab_content).padding([6, 12]).style(
+    // The tab background is painted by `hover_fade` so it can cross-fade on
+    // hover; the button itself stays transparent.
+    let tab_button_inner = button(tab_content).padding([6, 12]).style(
         move |_theme: &Theme, status: button::Status| {
             if is_active {
                 button::Style {
-                    background: Some(Background::Color(Color {
-                        a: inactive_alpha,
-                        ..palette.background
-                    })),
+                    background: Some(Background::Color(Color::TRANSPARENT)),
                     text_color: palette.text,
                     border: Border::default(),
                     shadow: iced::Shadow::default(),
@@ -304,14 +313,7 @@ fn browser_tab<'a>(
             } else {
                 let hovered = matches!(status, button::Status::Hovered);
                 button::Style {
-                    background: Some(Background::Color(if hovered {
-                        Color {
-                            a: 0.08,
-                            ..palette.text
-                        }
-                    } else {
-                        Color::TRANSPARENT
-                    })),
+                    background: Some(Background::Color(Color::TRANSPARENT)),
                     text_color: if hovered {
                         palette.text
                     } else {
@@ -323,6 +325,38 @@ fn browser_tab<'a>(
                 }
             }
         },
+    );
+
+    let (rest_bg, hover_bg) = if is_active {
+        let active_bg = Color {
+            a: inactive_alpha,
+            ..palette.background
+        };
+        (active_bg, active_bg)
+    } else {
+        (
+            Color::TRANSPARENT,
+            Color {
+                a: 0.08,
+                ..palette.text
+            },
+        )
+    };
+    let tab_button = hover_fade(
+        tab_button_inner,
+        HoverStyle {
+            background: rest_bg,
+            border_color: Color::TRANSPARENT,
+            border_width: 0.0,
+            radius: 0.0,
+        },
+        HoverStyle {
+            background: hover_bg,
+            border_color: Color::TRANSPARENT,
+            border_width: 0.0,
+            radius: 0.0,
+        },
+        animations_enabled,
     );
 
     if is_active {

--- a/src/gui/settings/appearance.rs
+++ b/src/gui/settings/appearance.rs
@@ -6,11 +6,11 @@ use crate::gui::settings::{
 };
 use crate::gui::theme::{Palette, SPACING_NORMAL};
 use crate::i18n::AVAILABLE_LOCALES;
-use iced::widget::{checkbox, column, combo_box, row, text};
+use iced::widget::{checkbox, column, combo_box, row, text, toggler};
 use iced::{Alignment, Element, Length};
 
 pub fn view<'a>(
-    _config: &'a AppConfig,
+    config: &'a AppConfig,
     draft: &'a SettingsDraft,
     font_combo_state: &'a combo_box::State<TerminalFontOption>,
     show_all_fonts: bool,
@@ -19,7 +19,7 @@ pub fn view<'a>(
 ) -> Element<'a, Message> {
     let language_section = section(
         t!("settings.language.section_title"),
-        language_picker(&draft.language, palette),
+        language_picker(&draft.language, palette, config.ui.animations_enabled),
         palette,
     );
 
@@ -111,12 +111,31 @@ pub fn view<'a>(
                 })
                 .collect(),
             palette,
+            config.ui.animations_enabled,
         ),
+        palette,
+    );
+
+    let animations_section = section(
+        crate::t!("settings.appearance.animations_section"),
+        row![
+            text(crate::t!("settings.appearance.animations"))
+                .size(13)
+                .width(Length::Fixed(160.0)),
+            toggler(draft.animations_enabled)
+                .on_toggle(Message::SettingsAnimationsToggled)
+                .size(18),
+        ]
+        .align_y(Alignment::Center)
+        .spacing(SPACING_NORMAL)
+        .width(Length::Fill)
+        .into(),
         palette,
     );
 
     column(vec![
         language_section,
+        animations_section,
         font_section,
         padding_section,
         cursor_section,
@@ -134,7 +153,11 @@ fn cursor_shape_label(shape: CursorShape) -> &'static str {
     }
 }
 
-fn language_picker<'a>(current: &'a str, palette: Palette) -> Element<'a, Message> {
+fn language_picker<'a>(
+    current: &'a str,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
     let mut segments: Vec<(&'a str, Message, bool)> =
         Vec::with_capacity(AVAILABLE_LOCALES.len() + 1);
     segments.push((
@@ -152,5 +175,5 @@ fn language_picker<'a>(current: &'a str, palette: Palette) -> Element<'a, Messag
             current == locale.tag,
         ));
     }
-    segmented_control("", segments, palette)
+    segmented_control("", segments, palette, animations_enabled)
 }

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -228,6 +228,7 @@ pub struct SettingsDraft {
     pub cursor: String,
     pub background_opacity: String,
     pub blur_enabled: bool,
+    pub animations_enabled: bool,
     pub macos_blur_radius: String,
     pub shortcut_new_tab: String,
     pub shortcut_close_tab: String,
@@ -268,6 +269,7 @@ impl SettingsDraft {
             cursor: format_rgb(config.theme.cursor),
             background_opacity: format!("{:.2}", config.theme.background_opacity),
             blur_enabled: config.theme.blur_enabled,
+            animations_enabled: config.ui.animations_enabled,
             macos_blur_radius: format!("{}", config.theme.macos_blur_radius),
             shortcut_new_tab: config.shortcuts.new_tab.clone(),
             shortcut_close_tab: config.shortcuts.close_tab.clone(),
@@ -468,6 +470,7 @@ impl SettingsDraft {
 
         let mut updates = AppConfigUpdates {
             language: Some(self.language.clone()),
+            animations_enabled: Some(self.animations_enabled),
             terminal_font_selection: Some(self.terminal_font_selection.clone()),
             terminal_font_size: parse_f32(&self.terminal_font_size),
             terminal_padding_x: parse_f32(&self.terminal_padding_x),
@@ -685,11 +688,18 @@ pub fn segmented_control<'a>(
     label: &'a str,
     segments: Vec<(&'a str, Message, bool)>,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let buttons: Vec<Element<'a, Message>> = segments
         .into_iter()
         .map(|(segment_label, message, selected)| {
-            segment_button(segment_label, message, selected, palette)
+            segment_button(
+                segment_label,
+                message,
+                selected,
+                palette,
+                animations_enabled,
+            )
         })
         .collect();
 
@@ -708,12 +718,16 @@ fn segment_button<'a>(
     message: Message,
     selected: bool,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let accent = palette.accent;
     let text_color = palette.text;
     let surface = palette.surface;
 
-    button(
+    // The visible background + border is painted by `hover_fade` behind the
+    // button so it can cross-fade on hover; the button itself stays
+    // transparent.
+    let inner = button(
         text(label)
             .size(13)
             .color(if selected { accent } else { text_color }),
@@ -721,27 +735,51 @@ fn segment_button<'a>(
     .on_press(message)
     .padding([6, 14])
     .style(move |_theme: &iced::Theme, _status| button::Style {
-        background: Some(Background::Color(Color {
-            a: if selected { 0.25 } else { 0.12 },
-            ..surface
-        })),
+        background: Some(Background::Color(Color::TRANSPARENT)),
         text_color: if selected { accent } else { text_color },
         border: Border {
             radius: RADIUS_SMALL.into(),
-            width: if selected { 1.5 } else { 1.0 },
-            color: if selected {
-                accent
-            } else {
-                Color {
-                    a: 0.15,
-                    ..text_color
-                }
-            },
+            width: 0.0,
+            color: Color::TRANSPARENT,
         },
         shadow: Default::default(),
         snap: true,
-    })
-    .into()
+    });
+
+    let rest = if selected {
+        crate::gui::components::HoverStyle {
+            background: Color { a: 0.25, ..surface },
+            border_color: accent,
+            border_width: 1.5,
+            radius: RADIUS_SMALL,
+        }
+    } else {
+        crate::gui::components::HoverStyle {
+            background: Color { a: 0.12, ..surface },
+            border_color: Color {
+                a: 0.15,
+                ..text_color
+            },
+            border_width: 1.0,
+            radius: RADIUS_SMALL,
+        }
+    };
+    // Selected segments do not change on hover; non-selected ones brighten.
+    let hover = if selected {
+        rest
+    } else {
+        crate::gui::components::HoverStyle {
+            background: Color { a: 0.2, ..surface },
+            border_color: Color {
+                a: 0.28,
+                ..text_color
+            },
+            border_width: 1.0,
+            radius: RADIUS_SMALL,
+        }
+    };
+
+    crate::gui::components::hover_fade(inner, rest, hover, animations_enabled).into()
 }
 
 pub fn hint_text<'a>(msg: &'a str, palette: Palette) -> Element<'a, Message> {

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -8,7 +8,7 @@ use iced::widget::{column, row, text, toggler};
 use iced::{Alignment, Element, Length};
 
 pub fn view<'a>(
-    _config: &'a AppConfig,
+    config: &'a AppConfig,
     draft: &'a SettingsDraft,
     palette: Palette,
 ) -> Element<'a, Message> {
@@ -104,6 +104,7 @@ pub fn view<'a>(
                 })
                 .collect(),
             palette,
+            config.ui.animations_enabled,
         ),
         palette,
     );


### PR DESCRIPTION
Closes #142.

인터랙티브 UI 요소에 부드러운 hover 전환 애니메이션을 추가하고, 설정으로 on/off합니다.

## 변경
- `hover_fade` 커스텀 위젯 — child를 감싸 `tree::State`에 `iced::Animation<bool>`을 들고, hover enter/leave 시 배경·테두리 색을 ~120ms ease-out으로 cross-fade. 애니 중 자체 redraw 요청
- 적용: 탭바 탭, 로비 세션 버튼, 설정 카테고리 내비, 세그먼트 컨트롤 버튼
- `Appearance` 카테고리에 "Animations" on/off 토글 — off면 즉시 전환
- `animations_enabled` config plumbing + i18n (en/ko)

build / clippy / test(--lib, 54 passed) / fmt 모두 통과.

> 참고: 애니메이션 실제 동작/클릭 정상 여부는 시각 확인 권장.