### PR TITLE
refactor: cursor shape — visual glyphs and move to Terminal

### DIFF
--- a/src/gui/settings/appearance.rs
+++ b/src/gui/settings/appearance.rs
@@ -1,4 +1,4 @@
-use crate::config::{AppConfig, CursorShape};
+use crate::config::AppConfig;
 use crate::gui::app::Message;
 use crate::gui::settings::{
     SettingsDraft, SettingsField, TerminalFontOption, hint_text, input_row_with_suffix, section,
@@ -96,26 +96,6 @@ pub fn view<'a>(
         palette,
     );
 
-    let cursor_section = section(
-        crate::t!("settings.terminal.cursor_section"),
-        segmented_control(
-            crate::t!("settings.terminal.shape"),
-            CursorShape::ALL
-                .iter()
-                .map(|&shape| {
-                    (
-                        cursor_shape_label(shape),
-                        Message::SettingsCursorShapeSelected(shape),
-                        draft.cursor_shape == shape,
-                    )
-                })
-                .collect(),
-            palette,
-            config.ui.animations_enabled,
-        ),
-        palette,
-    );
-
     let animations_section = section(
         crate::t!("settings.appearance.animations_section"),
         row![
@@ -138,19 +118,10 @@ pub fn view<'a>(
         animations_section,
         font_section,
         padding_section,
-        cursor_section,
     ])
     .spacing(SPACING_NORMAL)
     .width(Length::Fill)
     .into()
-}
-
-fn cursor_shape_label(shape: CursorShape) -> &'static str {
-    match shape {
-        CursorShape::Block => crate::t!("settings.terminal.cursor_shape.block"),
-        CursorShape::Bar => crate::t!("settings.terminal.cursor_shape.bar"),
-        CursorShape::Underline => crate::t!("settings.terminal.cursor_shape.underline"),
-    }
 }
 
 fn language_picker<'a>(

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -1,4 +1,4 @@
-use crate::config::{AppConfig, BellMode};
+use crate::config::{AppConfig, BellMode, CursorShape};
 use crate::gui::app::Message;
 use crate::gui::settings::{
     SettingsDraft, SettingsField, input_row_with_suffix, section, segmented_control,
@@ -74,15 +74,35 @@ pub fn view<'a>(
 
     let cursor_section = section(
         crate::t!("settings.terminal.cursor_section"),
-        row![
-            text(crate::t!("settings.terminal.blink"))
-                .size(13)
-                .width(label_width),
-            toggler(draft.cursor_blink)
-                .on_toggle(Message::SettingsCursorBlinkToggled)
-                .size(18),
-        ]
-        .align_y(Alignment::Center)
+        column(vec![
+            segmented_control(
+                crate::t!("settings.terminal.shape"),
+                CursorShape::ALL
+                    .iter()
+                    .map(|&shape| {
+                        (
+                            cursor_shape_label(shape),
+                            Message::SettingsCursorShapeSelected(shape),
+                            draft.cursor_shape == shape,
+                        )
+                    })
+                    .collect(),
+                palette,
+                config.ui.animations_enabled,
+            ),
+            row![
+                text(crate::t!("settings.terminal.blink"))
+                    .size(13)
+                    .width(label_width),
+                toggler(draft.cursor_blink)
+                    .on_toggle(Message::SettingsCursorBlinkToggled)
+                    .size(18),
+            ]
+            .align_y(Alignment::Center)
+            .spacing(SPACING_NORMAL)
+            .width(Length::Fill)
+            .into(),
+        ])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)
         .into(),
@@ -118,6 +138,15 @@ pub fn view<'a>(
     .spacing(SPACING_NORMAL)
     .width(Length::Fill)
     .into()
+}
+
+/// Glyphs that visually represent each cursor shape in the segmented control.
+fn cursor_shape_label(shape: CursorShape) -> &'static str {
+    match shape {
+        CursorShape::Block => "█",
+        CursorShape::Bar => "▎",
+        CursorShape::Underline => "▁",
+    }
 }
 
 fn bell_mode_label(mode: BellMode) -> &'static str {


### PR DESCRIPTION
Closes #145.

## 변경
- Cursor shape 세그먼트 컨트롤이 "Block/Bar/Underline" 텍스트 대신 **실제 모양 글리프**(█ / ▎ / ▁) 표시
- Cursor shape를 Appearance → **Terminal** 카테고리로 이동, Blink와 같은 "Cursor" 섹션으로 통합

## 결과 분류
- Appearance: Language, Animations, Font, Padding
- Terminal: Scrolling, Paste, **Cursor (shape + blink)**, Bell

build / clippy / test(--lib, 54 passed) / fmt 모두 통과.