### PR TITLE
feat: fade transition between settings categories

### DIFF
--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -186,6 +186,7 @@ pub struct App {
     pub(super) settings_debounce_seq: u64,
     pub(super) settings_debounce_spawned_seq: u64,
     pub(super) shell_picker_anim: Animation<bool>,
+    pub(super) settings_category_transition: crate::gui::components::CategoryTransition,
     pub(super) palette: crate::gui::theme::Palette,
     pub(super) ime_active: bool,
     pub(super) ime_preedit: Option<(String, Option<std::ops::Range<usize>>)>,
@@ -287,6 +288,7 @@ impl App {
             shell_picker_anim: Animation::new(false)
                 .duration(std::time::Duration::from_millis(250))
                 .easing(iced::animation::Easing::EaseOutQuint),
+            settings_category_transition: crate::gui::components::CategoryTransition::new(),
             window_style_applied: false,
             #[cfg(target_os = "macos")]
             show_restart_confirm: false,

--- a/src/gui/app/subscription.rs
+++ b/src/gui/app/subscription.rs
@@ -15,6 +15,7 @@ impl App {
             .is_some_and(|start| start.elapsed() < super::BELL_FLASH_DURATION);
         let has_animation = self.shell_picker_anim.is_animating(now)
             || self.tabs.iter().any(|tab| tab.sftp.anim.is_animating(now))
+            || self.settings_category_transition.is_animating(now)
             || bell_flashing;
 
         let animation_tick = if has_animation {

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -404,11 +404,18 @@ impl App {
                 self.settings_draft = SettingsDraft::from_config(&self.config);
             }
             Message::SelectSettingsCategory(category) => {
-                self.settings_category = category;
                 if !self.settings_open {
                     self.settings_open = true;
                     self.active_tab = SETTINGS_TAB_INDEX;
                     self.settings_draft = SettingsDraft::from_config(&self.config);
+                }
+                if let Some(immediate) = self.settings_category_transition.request_switch(
+                    category,
+                    self.settings_category,
+                    self.config.ui.animations_enabled,
+                    Instant::now(),
+                ) {
+                    self.settings_category = immediate;
                 }
             }
             Message::SettingsInputChanged(field, value) => {
@@ -665,6 +672,9 @@ impl App {
                     if !tab.sftp.anim.is_animating(now) && !tab.sftp.anim.value() {
                         tab.sftp.open = false;
                     }
+                }
+                if let Some(cat) = self.settings_category_transition.tick(now) {
+                    self.settings_category = cat;
                 }
                 if let Some(start) = self.bell_flash_start
                     && start.elapsed() >= super::BELL_FLASH_DURATION

--- a/src/gui/app/view/settings.rs
+++ b/src/gui/app/view/settings.rs
@@ -1,7 +1,7 @@
 use super::super::{App, Message};
 use crate::gui::settings::{self, SettingsCategory};
 use crate::gui::theme::{RADIUS_NORMAL, SPACING_LARGE, SPACING_NORMAL, SPACING_SMALL};
-use iced::widget::{button, column, container, row, scrollable, text};
+use iced::widget::{button, column, container, row, scrollable, stack, text};
 use iced::{Background, Border, Color, Element, Length};
 
 impl App {
@@ -121,12 +121,37 @@ impl App {
         .padding([0, 12])
         .width(Length::Fill);
 
-        let body = scrollable(body_content)
+        let body_scroll: Element<Message> = scrollable(body_content)
             .height(Length::Fill)
-            .width(Length::Fill);
+            .width(Length::Fill)
+            .into();
+
+        // Cross-fade overlay confined to the body area (sidebar stays put).
+        let body: Element<Message> = if let Some(alpha) = self
+            .settings_category_transition
+            .overlay_alpha(iced::time::Instant::now())
+        {
+            let overlay_color = Color {
+                a: alpha,
+                ..palette.background
+            };
+            let overlay = container("")
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .style(move |_theme: &iced::Theme| container::Style {
+                    background: Some(Background::Color(overlay_color)),
+                    ..Default::default()
+                });
+            stack![body_scroll, overlay]
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()
+        } else {
+            body_scroll
+        };
 
         let content = container(
-            column(vec![header, body.into()])
+            column(vec![header, body])
                 .spacing(SPACING_NORMAL)
                 .height(Length::Fill)
                 .width(Length::Fill),

--- a/src/gui/components/category_transition.rs
+++ b/src/gui/components/category_transition.rs
@@ -1,0 +1,165 @@
+//! Settings category fade transition.
+//!
+//! Encapsulates the cross-fade state machine used when the user switches
+//! between settings categories (Appearance / Terminal / Theme / Shortcuts /
+//! SSH). The body content fades out, the category is swapped, and the new
+//! content fades back in. View and update sites only delegate to this type;
+//! all animation state lives here.
+//!
+//! State machine (each tick of `iced::Animation<bool>`):
+//!
+//! ```text
+//!   Idle ──request_switch(target, animations_enabled=true)──▶ FadingOut(target)
+//!   FadingOut(pending) ──tick after fade-out completes──▶ FadingIn (and
+//!       returns `Some(pending)` so the caller swaps the live category)
+//!   FadingIn ──tick after fade-in completes──▶ Idle
+//! ```
+//!
+//! When `animations_enabled == false`, `request_switch` short-circuits and
+//! tells the caller to swap immediately without starting a transition.
+
+use crate::gui::settings::SettingsCategory;
+use iced::Animation;
+use iced::time::Instant;
+use std::time::Duration;
+
+/// One half of the cross-fade (out + in).
+const FADE_DURATION: Duration = Duration::from_millis(120);
+
+/// Current phase of the fade state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// No transition in flight.
+    Idle,
+    /// Body is fading to opaque; once complete the category swaps to `pending`.
+    FadingOut,
+    /// Body is fading back to transparent after the swap.
+    FadingIn,
+}
+
+/// State for the settings category fade transition. Single instance lives on
+/// `App`; view/update sites call into it instead of touching `Animation`.
+pub struct CategoryTransition {
+    /// Category to swap to once the fade-out phase finishes. Latest click wins
+    /// while we are still fading out.
+    pending: Option<SettingsCategory>,
+    phase: Phase,
+    /// `true` = overlay opaque (content hidden), `false` = overlay transparent
+    /// (content fully visible).
+    anim: Animation<bool>,
+}
+
+impl CategoryTransition {
+    pub fn new() -> Self {
+        Self {
+            pending: None,
+            phase: Phase::Idle,
+            anim: Animation::new(false)
+                .duration(FADE_DURATION)
+                .easing(iced::animation::Easing::EaseOut),
+        }
+    }
+
+    /// Request a category switch.
+    ///
+    /// * Returns `Some(target)` when the caller should update its
+    ///   `settings_category` immediately (animations disabled, target equals
+    ///   current, or we are already mid-transition into the same target).
+    /// * Returns `None` when a fade-out has been started; the caller should
+    ///   leave `settings_category` untouched and wait for `tick` to hand back
+    ///   the swap.
+    pub fn request_switch(
+        &mut self,
+        target: SettingsCategory,
+        current: SettingsCategory,
+        animations_enabled: bool,
+        now: Instant,
+    ) -> Option<SettingsCategory> {
+        if !animations_enabled {
+            // Reset any in-flight transition so we do not leave a stale overlay.
+            self.pending = None;
+            self.phase = Phase::Idle;
+            self.anim.go_mut(false, now - FADE_DURATION);
+            return Some(target);
+        }
+
+        if target == current && self.phase == Phase::Idle {
+            return Some(target);
+        }
+
+        match self.phase {
+            Phase::Idle => {
+                // No-op if we are already on the requested category.
+                if target == current {
+                    return Some(target);
+                }
+                self.pending = Some(target);
+                self.phase = Phase::FadingOut;
+                self.anim.go_mut(true, now);
+                None
+            }
+            Phase::FadingOut => {
+                // A later click during the fade-out just updates the target.
+                self.pending = Some(target);
+                None
+            }
+            Phase::FadingIn => {
+                // Clicked again while content was fading back in: restart from
+                // a fade-out toward the new target.
+                self.pending = Some(target);
+                self.phase = Phase::FadingOut;
+                self.anim.go_mut(true, now);
+                None
+            }
+        }
+    }
+
+    /// Drive the state machine. Call once per `AnimationTick`.
+    ///
+    /// Returns `Some(category)` exactly on the tick where the fade-out has
+    /// completed: the caller should set `settings_category = category` and the
+    /// fade-in is started internally.
+    pub fn tick(&mut self, now: Instant) -> Option<SettingsCategory> {
+        match self.phase {
+            Phase::Idle => None,
+            Phase::FadingOut => {
+                // Fade-out is finished when the animation has settled at the
+                // opaque end (value == true and not animating).
+                if !self.anim.is_animating(now) && self.anim.value() {
+                    let target = self.pending.take();
+                    self.phase = Phase::FadingIn;
+                    self.anim.go_mut(false, now);
+                    target
+                } else {
+                    None
+                }
+            }
+            Phase::FadingIn => {
+                if !self.anim.is_animating(now) && !self.anim.value() {
+                    self.phase = Phase::Idle;
+                }
+                None
+            }
+        }
+    }
+
+    /// Overlay alpha in `[0.0, 1.0]`, or `None` when no transition is active.
+    pub fn overlay_alpha(&self, now: Instant) -> Option<f32> {
+        if self.phase == Phase::Idle {
+            return None;
+        }
+        let alpha = self.anim.interpolate(0.0, 1.0, now).clamp(0.0, 1.0);
+        Some(alpha)
+    }
+
+    /// Whether a redraw should be scheduled for the next frame.
+    pub fn is_animating(&self, now: Instant) -> bool {
+        self.anim.is_animating(now) || self.phase != Phase::Idle
+    }
+}
+
+impl Default for CategoryTransition {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/gui/components/mod.rs
+++ b/src/gui/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod button;
+pub mod category_transition;
 pub mod container;
 pub mod context_menu;
 pub mod hover_fade;
@@ -21,6 +22,7 @@ pub fn button_secondary(
     button::secondary(text, palette)
 }
 
+pub use category_transition::CategoryTransition;
 pub use container::panel;
 pub use hover_fade::{HoverStyle, hover_fade};
 pub use tab_bar::tab_bar;


### PR DESCRIPTION
Closes #147.

설정 패널에서 카테고리(모양/Terminal/Theme/Shortcuts/SSH) 전환 시 페이드 아웃 → 스왑 → 페이드 인.

## 구조
애니 로직 전부 신규 모듈에 캡슐화:
- `src/gui/components/category_transition.rs` — `CategoryTransition` (상태머신 Idle/FadingOut/FadingIn + `iced::Animation<bool>`)
- view/update는 위임만 (1~2줄)

## 동작
- 페이드아웃 120ms ease-out → 스왑 → 페이드인 120ms (총 ~240ms)
- body content 영역만 페이드 (사이드바는 그대로)
- `Appearance > Animations` 토글 off면 즉시 스왑
- 전환 중 다른 카테고리 클릭 → 마지막 클릭 대상으로 갱신만 (재시작 X)

build / clippy / test(--lib, 54 passed) / fmt 모두 통과.