### PR TITLE
style: align toggler and combo_box with palette accent

### DIFF
--- a/src/gui/components/mod.rs
+++ b/src/gui/components/mod.rs
@@ -5,6 +5,7 @@ pub mod context_menu;
 pub mod hover_fade;
 pub mod ime_wrapper;
 pub mod tab_bar;
+pub mod widget_styles;
 
 use crate::gui::theme::Palette;
 
@@ -26,3 +27,6 @@ pub use category_transition::CategoryTransition;
 pub use container::panel;
 pub use hover_fade::{HoverStyle, hover_fade};
 pub use tab_bar::tab_bar;
+pub use widget_styles::{
+    accent_combo_box_input_style, accent_combo_box_menu_style, accent_toggler_style,
+};

--- a/src/gui/components/widget_styles.rs
+++ b/src/gui/components/widget_styles.rs
@@ -1,0 +1,156 @@
+//! Accent-driven style helpers for `toggler` and `combo_box` widgets so they
+//! visually match the rest of the UI (which derives colors from
+//! `palette.accent`) instead of iced's default blue accent.
+
+use crate::gui::theme::{Palette, RADIUS_SMALL};
+use iced::widget::overlay::menu;
+use iced::widget::{text_input, toggler};
+use iced::{Background, Border, Color, Shadow, Theme};
+
+/// Style closure for `toggler` widgets driven by `palette.accent`.
+///
+/// Visual treatment:
+/// - On + active/hovered → accent background, knob = `palette.background`.
+/// - Off + active        → dim text-tinted background, knob = secondary text.
+/// - Hovered             → slightly brighter than the active variant.
+/// - Disabled            → faded to ~30% alpha to read as inert.
+pub fn accent_toggler_style(
+    palette: Palette,
+) -> impl Fn(&Theme, toggler::Status) -> toggler::Style {
+    move |_theme: &Theme, status: toggler::Status| {
+        // Off-state background: a subtle text-tinted fill matching the
+        // visual weight of the `button_secondary` resting state.
+        let off_bg = Color {
+            a: 0.18,
+            ..palette.text
+        };
+        let off_bg_hover = Color {
+            a: 0.26,
+            ..palette.text
+        };
+
+        // On-state background: the palette accent, slightly brightened on
+        // hover (mirrors `button_primary`).
+        let on_bg = palette.accent;
+        let on_bg_hover = Color {
+            r: (palette.accent.r * 1.1).min(1.0),
+            g: (palette.accent.g * 1.1).min(1.0),
+            b: (palette.accent.b * 1.1).min(1.0),
+            a: 1.0,
+        };
+
+        let (background, foreground) = match status {
+            toggler::Status::Active { is_toggled: true } => (on_bg, palette.background),
+            toggler::Status::Active { is_toggled: false } => (off_bg, palette.text_secondary),
+            toggler::Status::Hovered { is_toggled: true } => (on_bg_hover, palette.background),
+            toggler::Status::Hovered { is_toggled: false } => (off_bg_hover, palette.text),
+            toggler::Status::Disabled { is_toggled: true } => (
+                Color {
+                    a: 0.3,
+                    ..palette.accent
+                },
+                Color {
+                    a: 0.5,
+                    ..palette.background
+                },
+            ),
+            toggler::Status::Disabled { is_toggled: false } => (
+                Color {
+                    a: 0.08,
+                    ..palette.text
+                },
+                Color {
+                    a: 0.3,
+                    ..palette.text_secondary
+                },
+            ),
+        };
+
+        toggler::Style {
+            background: Background::Color(background),
+            background_border_width: 0.0,
+            background_border_color: Color::TRANSPARENT,
+            foreground: Background::Color(foreground),
+            foreground_border_width: 0.0,
+            foreground_border_color: Color::TRANSPARENT,
+            text_color: None,
+            border_radius: None,
+            padding_ratio: 0.1,
+        }
+    }
+}
+
+/// Style closure for the text-input portion of a `combo_box`.
+/// Mirrors the project's `styled_text_input`: subtle background, accent
+/// border on focus, accent-tinted selection.
+pub fn accent_combo_box_input_style(
+    palette: Palette,
+) -> impl Fn(&Theme, text_input::Status) -> text_input::Style {
+    move |_theme: &Theme, status: text_input::Status| {
+        let focused = matches!(status, text_input::Status::Focused { .. });
+        let hovered = matches!(status, text_input::Status::Hovered);
+
+        let border_color = if focused {
+            Color {
+                a: 0.5,
+                ..palette.accent
+            }
+        } else if hovered {
+            Color {
+                a: 0.25,
+                ..palette.text
+            }
+        } else {
+            Color {
+                a: 0.12,
+                ..palette.text
+            }
+        };
+
+        text_input::Style {
+            background: Background::Color(Color {
+                a: 0.35,
+                ..palette.background
+            }),
+            border: Border {
+                radius: RADIUS_SMALL.into(),
+                width: 1.0,
+                color: border_color,
+            },
+            icon: palette.text_secondary,
+            placeholder: palette.text_secondary,
+            value: palette.text,
+            // Cursor color and selection both pull from the accent.
+            selection: Color {
+                a: 0.3,
+                ..palette.accent
+            },
+        }
+    }
+}
+
+/// Style closure for the dropdown menu of a `combo_box`.
+/// In iced 0.14, `menu::StyleFn` takes only `&Theme` — there is no per-item
+/// hover state exposed here, so the "hovered item" visual is whatever
+/// `selected_background` paints (iced highlights the row under the cursor
+/// using the selected style). We tint that with the palette accent.
+pub fn accent_combo_box_menu_style(palette: Palette) -> impl Fn(&Theme) -> menu::Style {
+    move |_theme: &Theme| menu::Style {
+        background: Background::Color(palette.surface),
+        border: Border {
+            radius: RADIUS_SMALL.into(),
+            width: 1.0,
+            color: Color {
+                a: 0.15,
+                ..palette.text
+            },
+        },
+        text_color: palette.text,
+        selected_text_color: palette.background,
+        selected_background: Background::Color(Color {
+            a: 0.9,
+            ..palette.accent
+        }),
+        shadow: Shadow::default(),
+    }
+}

--- a/src/gui/settings/appearance.rs
+++ b/src/gui/settings/appearance.rs
@@ -1,5 +1,8 @@
 use crate::config::AppConfig;
 use crate::gui::app::Message;
+use crate::gui::components::{
+    accent_combo_box_input_style, accent_combo_box_menu_style, accent_toggler_style,
+};
 use crate::gui::settings::{
     SettingsDraft, SettingsField, TerminalFontOption, hint_text, input_row_with_suffix, section,
     segmented_control,
@@ -43,7 +46,9 @@ pub fn view<'a>(
                     selected_font,
                     Message::FontSelected,
                 )
-                .width(Length::Fill),
+                .width(Length::Fill)
+                .input_style(accent_combo_box_input_style(palette))
+                .menu_style(accent_combo_box_menu_style(palette)),
             ]
             .align_y(Alignment::Center)
             .spacing(SPACING_NORMAL)
@@ -104,7 +109,8 @@ pub fn view<'a>(
                 .width(Length::Fixed(160.0)),
             toggler(draft.animations_enabled)
                 .on_toggle(Message::SettingsAnimationsToggled)
-                .size(18),
+                .size(18)
+                .style(accent_toggler_style(palette)),
         ]
         .align_y(Alignment::Center)
         .spacing(SPACING_NORMAL)

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -2,6 +2,7 @@ use crate::config::{
     AppConfig, AppConfigUpdates, BellMode, CursorShape, SshAuthMethod, SshProfile, parse_hex_color,
 };
 use crate::gui::app::Message;
+use crate::gui::components::accent_toggler_style;
 use crate::gui::theme::{Palette, RADIUS_NORMAL, RADIUS_SMALL, SPACING_NORMAL};
 use iced::widget::{button, column, container, row, rule, text, text_input, toggler};
 use iced::{Alignment, Background, Border, Color, Element, Length};
@@ -668,12 +669,13 @@ pub fn color_input_row<'a>(
     .into()
 }
 
-pub fn toggle_row<'a>(label: &'a str, value: bool) -> Element<'a, Message> {
+pub fn toggle_row<'a>(label: &'a str, value: bool, palette: Palette) -> Element<'a, Message> {
     row![
         text(label).size(13).width(Length::Fixed(LABEL_WIDTH)),
         toggler(value)
             .on_toggle(Message::SettingsBlurToggled)
             .size(18)
+            .style(accent_toggler_style(palette))
     ]
     .align_y(Alignment::Center)
     .spacing(SPACING_NORMAL)

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -1,5 +1,6 @@
 use crate::config::{AppConfig, BellMode, CursorShape};
 use crate::gui::app::Message;
+use crate::gui::components::accent_toggler_style;
 use crate::gui::settings::{
     SettingsDraft, SettingsField, input_row_with_suffix, section, segmented_control,
 };
@@ -47,7 +48,8 @@ pub fn view<'a>(
                     .width(label_width),
                 toggler(draft.bracketed_paste)
                     .on_toggle(Message::SettingsBracketedPasteToggled)
-                    .size(18),
+                    .size(18)
+                    .style(accent_toggler_style(palette)),
             ]
             .align_y(Alignment::Center)
             .spacing(SPACING_NORMAL)
@@ -59,7 +61,8 @@ pub fn view<'a>(
                     .width(label_width),
                 toggler(draft.multiline_paste_confirm)
                     .on_toggle(Message::SettingsMultilinePasteConfirmToggled)
-                    .size(18),
+                    .size(18)
+                    .style(accent_toggler_style(palette)),
             ]
             .align_y(Alignment::Center)
             .spacing(SPACING_NORMAL)
@@ -96,7 +99,8 @@ pub fn view<'a>(
                     .width(label_width),
                 toggler(draft.cursor_blink)
                     .on_toggle(Message::SettingsCursorBlinkToggled)
-                    .size(18),
+                    .size(18)
+                    .style(accent_toggler_style(palette)),
             ]
             .align_y(Alignment::Center)
             .spacing(SPACING_NORMAL)

--- a/src/gui/settings/theme.rs
+++ b/src/gui/settings/theme.rs
@@ -81,6 +81,7 @@ pub fn view<'a>(
         column(vec![toggle_row(
             crate::t!("settings.theme.enable_blur"),
             draft.blur_enabled,
+            palette,
         )])
         .spacing(SPACING_NORMAL)
         .width(Length::Fill)


### PR DESCRIPTION
Closes #149.

`toggler`·`combo_box` 위젯이 iced 기본 파랑 대신 앱의 `palette.accent`를 따르도록 통일.

## 변경
- `components/widget_styles.rs` 신규 — `accent_toggler_style`, `accent_combo_box_input_style`, `accent_combo_box_menu_style`
- 모든 `toggler` 호출 사이트에 적용 (Bracketed paste / Multi-line confirm / Cursor blink / Animations / Blur via `toggle_row`)
- Font family `combo_box`에 `.input_style` + `.menu_style` 적용
- `toggle_row(label, value)` → `toggle_row(label, value, palette)` (caller 1곳 갱신)

## 한계
iced 0.14의 `combo_box::menu_style`는 `Fn(&Theme) -> Style` 시그니처라 per-item hover 상태가 안 들어옴. 그래서 hover/selected 행이 같은 accent 하이라이트 공유 — iced API 한계.

build / clippy / test(--lib, 54 passed) / fmt 모두 통과.