### PR TITLE
refactor: unify button hover animations through factory helpers

### DIFF
--- a/src/gui/app/view/dialog.rs
+++ b/src/gui/app/view/dialog.rs
@@ -1,6 +1,7 @@
 use super::super::Message;
-use crate::gui::theme::{Palette, RADIUS_NORMAL, RADIUS_SMALL, SPACING_NORMAL, SPACING_SMALL};
-use iced::widget::{button, center, column, container, mouse_area, row, stack, text};
+use crate::gui::components::{primary, secondary};
+use crate::gui::theme::{Palette, RADIUS_NORMAL, SPACING_NORMAL, SPACING_SMALL};
+use iced::widget::{center, column, container, mouse_area, row, stack, text};
 use iced::{Background, Border, Color, Element, Length};
 
 pub(in crate::gui) struct DialogButton {
@@ -9,6 +10,7 @@ pub(in crate::gui) struct DialogButton {
     pub primary: bool,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::gui) fn confirm_dialog<'a>(
     base_layout: impl Into<Element<'a, Message>>,
     title: &str,
@@ -16,6 +18,7 @@ pub(in crate::gui) fn confirm_dialog<'a>(
     buttons: Vec<DialogButton>,
     on_dismiss: Message,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let backdrop = mouse_area(
         container(text(""))
@@ -36,56 +39,11 @@ pub(in crate::gui) fn confirm_dialog<'a>(
     let button_row: Vec<Element<Message>> = buttons
         .into_iter()
         .map(|btn| {
-            let is_primary = btn.primary;
-            button(text(btn.label).size(13))
-                .style(
-                    move |_theme: &iced::Theme, status: iced::widget::button::Status| {
-                        let hovered = matches!(status, iced::widget::button::Status::Hovered);
-                        if is_primary {
-                            iced::widget::button::Style {
-                                background: Some(Background::Color(if hovered {
-                                    Color {
-                                        a: 0.9,
-                                        ..palette.accent
-                                    }
-                                } else {
-                                    palette.accent
-                                })),
-                                text_color: palette.background,
-                                border: Border {
-                                    radius: RADIUS_SMALL.into(),
-                                    ..Default::default()
-                                },
-                                shadow: iced::Shadow::default(),
-                                snap: true,
-                            }
-                        } else {
-                            iced::widget::button::Style {
-                                background: Some(Background::Color(if hovered {
-                                    Color {
-                                        a: 0.15,
-                                        ..palette.text
-                                    }
-                                } else {
-                                    Color {
-                                        a: 0.08,
-                                        ..palette.text
-                                    }
-                                })),
-                                text_color: palette.text,
-                                border: Border {
-                                    radius: RADIUS_SMALL.into(),
-                                    ..Default::default()
-                                },
-                                shadow: iced::Shadow::default(),
-                                snap: true,
-                            }
-                        }
-                    },
-                )
-                .padding([6, 14])
-                .on_press(btn.message)
-                .into()
+            if btn.primary {
+                primary(btn.label, btn.message, palette, animations_enabled)
+            } else {
+                secondary(btn.label, Some(btn.message), palette, animations_enabled)
+            }
         })
         .collect();
 

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -9,7 +9,7 @@ pub(in crate::gui) use dialog::{DialogButton, confirm_dialog};
 use super::{App, Message, SETTINGS_TAB_INDEX};
 use crate::gui::components::context_menu::{ContextMenuItem, context_menu};
 use crate::gui::components::ime_wrapper::ImeEnabled;
-use crate::gui::components::{button_secondary, panel, tab_bar};
+use crate::gui::components::{panel, secondary as button_secondary, tab_bar};
 use crate::gui::render::TerminalProgram;
 use crate::gui::theme::{RADIUS_SMALL, SPACING_SMALL};
 use iced::widget::{button, column, container, image, row, scrollable, stack, text};
@@ -101,6 +101,7 @@ impl App {
                 ],
                 Message::CancelRestartForBlur,
                 palette,
+                self.config.ui.animations_enabled,
             );
         }
 
@@ -125,6 +126,7 @@ impl App {
                 ],
                 Message::CancelMultilinePaste,
                 palette,
+                self.config.ui.animations_enabled,
             );
         }
 
@@ -221,11 +223,15 @@ impl App {
             let effective = (height_ratio * drawer_progress).clamp(0.0, height_ratio);
             let bottom_portion = ((effective * 1000.0).round() as u16).max(1);
             let top_portion = 1000u16.saturating_sub(bottom_portion).max(1);
-            let drawer_panel =
-                container(sftp::drawer(&active_tab.sftp, active_tab.id, self.palette))
-                    .width(Length::Fill)
-                    .height(Length::FillPortion(bottom_portion))
-                    .clip(true);
+            let drawer_panel = container(sftp::drawer(
+                &active_tab.sftp,
+                active_tab.id,
+                self.palette,
+                self.config.ui.animations_enabled,
+            ))
+            .width(Length::Fill)
+            .height(Length::FillPortion(bottom_portion))
+            .clip(true);
             let overlay = column![
                 iced::widget::Space::new().height(Length::FillPortion(top_portion)),
                 drawer_panel,
@@ -293,11 +299,15 @@ impl App {
         let version_label = text(format!("RabbiTTY v{}", env!("CARGO_PKG_VERSION")))
             .size(13)
             .color(Color::from_rgba(1.0, 1.0, 1.0, 0.4));
-        let new_tab_btn =
-            button_secondary(t!("lobby.new_tab"), palette).on_press(Message::OpenShellPicker);
+        let new_tab_btn = button_secondary(
+            t!("lobby.new_tab"),
+            Some(Message::OpenShellPicker),
+            palette,
+            self.config.ui.animations_enabled,
+        );
 
         let mut content: Vec<Element<Message>> =
-            vec![logo.into(), version_label.into(), new_tab_btn.into()];
+            vec![logo.into(), version_label.into(), new_tab_btn];
 
         if !self.session_history.entries.is_empty() {
             content.push(
@@ -422,6 +432,7 @@ impl App {
             self.cursor_position,
             Message::CloseTabContextMenu,
             self.palette,
+            self.config.ui.animations_enabled,
         )
     }
 }

--- a/src/gui/app/view/settings.rs
+++ b/src/gui/app/view/settings.rs
@@ -167,7 +167,12 @@ impl App {
             .into();
 
         if matches!(self.settings_category, SettingsCategory::Ssh) {
-            settings::ssh::modal_overlay(settings_layout, &self.settings_draft, palette)
+            settings::ssh::modal_overlay(
+                settings_layout,
+                &self.settings_draft,
+                palette,
+                animations_enabled,
+            )
         } else {
             settings_layout
         }

--- a/src/gui/app/view/sftp.rs
+++ b/src/gui/app/view/sftp.rs
@@ -1,6 +1,7 @@
 //! SFTP drawer rendering.
 
 use crate::gui::app::Message;
+use crate::gui::components::{HoverStyle, hover_fade};
 use crate::gui::sftp::{self, SftpDrawerState, TransferRow};
 use crate::gui::theme::{Palette, RADIUS_NORMAL, RADIUS_SMALL, SPACING_NORMAL, SPACING_SMALL};
 use crate::ssh::sftp::Entry;
@@ -14,8 +15,9 @@ pub fn drawer<'a>(
     state: &'a SftpDrawerState,
     tab_id: u64,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
-    let header = drawer_header(state, palette);
+    let header = drawer_header(state, palette, animations_enabled);
     let separator = container("")
         .width(Length::Fill)
         .height(Length::Fixed(1.0))
@@ -26,11 +28,11 @@ pub fn drawer<'a>(
             })),
             ..Default::default()
         });
-    let body = drawer_body(state, tab_id, palette);
+    let body = drawer_body(state, tab_id, palette, animations_enabled);
 
     let mut layers: Vec<Element<Message>> = vec![header, separator.into(), body];
     if !state.transfers.is_empty() {
-        layers.push(transfer_strip(state, palette));
+        layers.push(transfer_strip(state, palette, animations_enabled));
     }
 
     container(column(layers).width(Length::Fill).height(Length::Fill))
@@ -65,7 +67,11 @@ pub fn drawer<'a>(
         .into()
 }
 
-fn drawer_header<'a>(state: &'a SftpDrawerState, palette: Palette) -> Element<'a, Message> {
+fn drawer_header<'a>(
+    state: &'a SftpDrawerState,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
     let path = if state.current_path.is_empty() {
         "~"
     } else {
@@ -97,38 +103,24 @@ fn drawer_header<'a>(state: &'a SftpDrawerState, palette: Palette) -> Element<'a
             .into(),
     };
 
-    let icon_style = move |_theme: &Theme, status: button::Status| button::Style {
-        background: Some(Background::Color(match status {
-            button::Status::Hovered => Color {
-                a: 0.08,
-                ..palette.text
-            },
-            _ => Color::TRANSPARENT,
-        })),
-        text_color: Color {
-            a: 0.7,
-            ..palette.text
-        },
-        border: Border {
-            radius: RADIUS_SMALL.into(),
-            width: 0.0,
-            color: Color::TRANSPARENT,
-        },
-        shadow: Shadow::default(),
-        snap: true,
-    };
-    let upload_btn = button(text("\u{2191}").size(12))
-        .on_press(Message::SftpRequestUpload)
-        .padding([3, 8])
-        .style(icon_style);
-    let refresh_btn = button(text("\u{27F3}").size(12))
-        .on_press(Message::SftpRefresh)
-        .padding([3, 8])
-        .style(icon_style);
-    let close_btn = button(text("\u{2715}").size(11))
-        .on_press(Message::SftpToggleDrawer)
-        .padding([3, 8])
-        .style(icon_style);
+    let upload_btn = drawer_icon_button(
+        "\u{2191}",
+        Message::SftpRequestUpload,
+        palette,
+        animations_enabled,
+    );
+    let refresh_btn = drawer_icon_button(
+        "\u{27F3}",
+        Message::SftpRefresh,
+        palette,
+        animations_enabled,
+    );
+    let close_btn = drawer_icon_button(
+        "\u{2715}",
+        Message::SftpToggleDrawer,
+        palette,
+        animations_enabled,
+    );
 
     container(
         row![
@@ -148,10 +140,54 @@ fn drawer_header<'a>(state: &'a SftpDrawerState, palette: Palette) -> Element<'a
     .into()
 }
 
+/// Small icon button used by the SFTP drawer header. Uses a slightly tighter
+/// padding than the global `icon` factory so it fits the header height.
+fn drawer_icon_button<'a>(
+    glyph: &'a str,
+    on_press: Message,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
+    let inner = button(text(glyph.to_string()).size(12))
+        .on_press(on_press)
+        .padding([3, 8])
+        .style(
+            move |_theme: &Theme, _status: button::Status| button::Style {
+                background: Some(Background::Color(Color::TRANSPARENT)),
+                text_color: Color {
+                    a: 0.7,
+                    ..palette.text
+                },
+                border: Border {
+                    radius: RADIUS_SMALL.into(),
+                    width: 0.0,
+                    color: Color::TRANSPARENT,
+                },
+                shadow: Shadow::default(),
+                snap: true,
+            },
+        );
+    let rest = HoverStyle {
+        background: Color::TRANSPARENT,
+        border_color: Color::TRANSPARENT,
+        border_width: 0.0,
+        radius: RADIUS_SMALL,
+    };
+    let hover = HoverStyle {
+        background: Color {
+            a: 0.08,
+            ..palette.text
+        },
+        ..rest
+    };
+    hover_fade(inner, rest, hover, animations_enabled).into()
+}
+
 fn drawer_body<'a>(
     state: &'a SftpDrawerState,
     tab_id: u64,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     if let Some(error) = state.error.as_deref() {
         return centered_message(error, palette.error, palette);
@@ -167,8 +203,8 @@ fn drawer_body<'a>(
         );
     }
 
-    let parent_element =
-        sftp::parent_path(&state.current_path).map(|p| parent_row(tab_id, p, palette));
+    let parent_element = sftp::parent_path(&state.current_path)
+        .map(|p| parent_row(tab_id, p, palette, animations_enabled));
 
     if state.entries.is_empty() {
         let empty = centered_message(
@@ -193,7 +229,7 @@ fn drawer_body<'a>(
         rows.push(parent);
     }
     for entry in &state.entries {
-        rows.push(entry_row(state, tab_id, entry, palette));
+        rows.push(entry_row(state, tab_id, entry, palette, animations_enabled));
     }
 
     scrollable(column(rows).width(Length::Fill).padding(iced::Padding {
@@ -215,9 +251,14 @@ fn centered_message<'a>(msg: &'a str, color: Color, _palette: Palette) -> Elemen
         .into()
 }
 
-fn parent_row<'a>(tab_id: u64, parent: String, palette: Palette) -> Element<'a, Message> {
+fn parent_row<'a>(
+    tab_id: u64,
+    parent: String,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
     let row_style = row_style_factory(palette);
-    button(
+    let inner = button(
         row![
             text("\u{2190}").size(11).color(Color {
                 a: 0.55,
@@ -238,7 +279,13 @@ fn parent_row<'a>(tab_id: u64, parent: String, palette: Palette) -> Element<'a, 
     .padding([3.0, SPACING_NORMAL])
     .width(Length::Fill)
     .height(Length::Fixed(ROW_HEIGHT))
-    .style(row_style)
+    .style(row_style);
+    hover_fade(
+        inner,
+        row_rest_style(),
+        row_hover_style(palette),
+        animations_enabled,
+    )
     .into()
 }
 
@@ -247,6 +294,7 @@ fn entry_row<'a>(
     tab_id: u64,
     entry: &'a Entry,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let marker = if entry.is_dir {
         "\u{25B8}"
@@ -319,18 +367,41 @@ fn entry_row<'a>(
     if let Some(msg) = press_msg {
         btn = btn.on_press(msg);
     }
-    btn.into()
+    hover_fade(
+        btn,
+        row_rest_style(),
+        row_hover_style(palette),
+        animations_enabled,
+    )
+    .into()
+}
+
+fn row_rest_style() -> HoverStyle {
+    HoverStyle {
+        background: Color::TRANSPARENT,
+        border_color: Color::TRANSPARENT,
+        border_width: 0.0,
+        radius: RADIUS_SMALL,
+    }
+}
+
+fn row_hover_style(palette: Palette) -> HoverStyle {
+    HoverStyle {
+        background: Color {
+            a: 0.06,
+            ..palette.text
+        },
+        border_color: Color::TRANSPARENT,
+        border_width: 0.0,
+        radius: RADIUS_SMALL,
+    }
 }
 
 fn row_style_factory(palette: Palette) -> impl Fn(&Theme, button::Status) -> button::Style + Copy {
-    move |_theme: &Theme, status: button::Status| button::Style {
-        background: Some(Background::Color(match status {
-            button::Status::Hovered => Color {
-                a: 0.06,
-                ..palette.text
-            },
-            _ => Color::TRANSPARENT,
-        })),
+    // Background is painted by `hover_fade` behind the button; the button
+    // itself stays transparent so the cross-fade can show through.
+    move |_theme: &Theme, _status: button::Status| button::Style {
+        background: Some(Background::Color(Color::TRANSPARENT)),
         text_color: palette.text,
         border: Border {
             radius: RADIUS_SMALL.into(),
@@ -342,7 +413,11 @@ fn row_style_factory(palette: Palette) -> impl Fn(&Theme, button::Status) -> but
     }
 }
 
-fn transfer_strip<'a>(state: &'a SftpDrawerState, palette: Palette) -> Element<'a, Message> {
+fn transfer_strip<'a>(
+    state: &'a SftpDrawerState,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
     let separator = container("")
         .width(Length::Fill)
         .height(Length::Fixed(1.0))
@@ -357,7 +432,7 @@ fn transfer_strip<'a>(state: &'a SftpDrawerState, palette: Palette) -> Element<'
     let rows: Vec<Element<Message>> = state
         .transfers
         .iter()
-        .map(|row| transfer_row(row, palette))
+        .map(|row| transfer_row(row, palette, animations_enabled))
         .collect();
 
     column![
@@ -371,7 +446,11 @@ fn transfer_strip<'a>(state: &'a SftpDrawerState, palette: Palette) -> Element<'
     .into()
 }
 
-fn transfer_row<'a>(row_state: &'a TransferRow, palette: Palette) -> Element<'a, Message> {
+fn transfer_row<'a>(
+    row_state: &'a TransferRow,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
     let name = row_state.path.rsplit('/').next().unwrap_or(&row_state.path);
     let progress = if row_state.total > 0 {
         (row_state.transferred as f32 / row_state.total as f32).clamp(0.0, 1.0)
@@ -415,14 +494,8 @@ fn transfer_row<'a>(row_state: &'a TransferRow, palette: Palette) -> Element<'a,
             })
             .into()
     } else {
-        let cancel_style = move |_theme: &Theme, status: button::Status| button::Style {
-            background: Some(Background::Color(match status {
-                button::Status::Hovered => Color {
-                    a: 0.12,
-                    ..palette.text
-                },
-                _ => Color::TRANSPARENT,
-            })),
+        let cancel_style = move |_theme: &Theme, _status: button::Status| button::Style {
+            background: Some(Background::Color(Color::TRANSPARENT)),
             text_color: Color {
                 a: 0.55,
                 ..palette.text
@@ -435,11 +508,24 @@ fn transfer_row<'a>(row_state: &'a TransferRow, palette: Palette) -> Element<'a,
             shadow: Shadow::default(),
             snap: true,
         };
-        button(text("\u{2715}").size(10))
+        let cancel_btn = button(text("\u{2715}").size(10))
             .on_press(Message::SftpCancelTransfer)
             .padding([2, 6])
-            .style(cancel_style)
-            .into()
+            .style(cancel_style);
+        let cancel_rest = HoverStyle {
+            background: Color::TRANSPARENT,
+            border_color: Color::TRANSPARENT,
+            border_width: 0.0,
+            radius: RADIUS_SMALL,
+        };
+        let cancel_hover = HoverStyle {
+            background: Color {
+                a: 0.12,
+                ..palette.text
+            },
+            ..cancel_rest
+        };
+        hover_fade(cancel_btn, cancel_rest, cancel_hover, animations_enabled).into()
     };
 
     container(

--- a/src/gui/app/view/shell_picker.rs
+++ b/src/gui/app/view/shell_picker.rs
@@ -30,6 +30,7 @@ struct ShellIcon {
 struct PickerStyle {
     alpha: f32,
     palette: Palette,
+    animations_enabled: bool,
 }
 
 impl PickerStyle {
@@ -102,22 +103,13 @@ impl PickerStyle {
             .spacing(10)
             .align_y(iced::Alignment::Center);
 
-        button(content)
+        // Background painted by `hover_fade` behind the button so the hover
+        // transition matches the rest of the app.
+        let inner = button(content)
             .style(
-                move |_theme: &iced::Theme, status: iced::widget::button::Status| {
-                    let hovered = matches!(status, iced::widget::button::Status::Hovered);
-                    let bg_alpha = if selected {
-                        0.15 * alpha
-                    } else if hovered {
-                        0.08 * alpha
-                    } else {
-                        0.0
-                    };
+                move |_theme: &iced::Theme, _status: iced::widget::button::Status| {
                     iced::widget::button::Style {
-                        background: Some(Background::Color(Color {
-                            a: bg_alpha,
-                            ..palette.text
-                        })),
+                        background: Some(Background::Color(Color::TRANSPARENT)),
                         text_color: Color {
                             a: alpha,
                             ..palette.text
@@ -134,8 +126,34 @@ impl PickerStyle {
             )
             .padding([6, 10])
             .on_press(on_press)
-            .width(Length::Fill)
-            .into()
+            .width(Length::Fill);
+
+        let rest = crate::gui::components::HoverStyle {
+            background: if selected {
+                Color {
+                    a: 0.15 * alpha,
+                    ..palette.text
+                }
+            } else {
+                Color::TRANSPARENT
+            },
+            border_color: Color::TRANSPARENT,
+            border_width: 0.0,
+            radius: RADIUS_SMALL,
+        };
+        let hover = if selected {
+            rest
+        } else {
+            crate::gui::components::HoverStyle {
+                background: Color {
+                    a: 0.08 * alpha,
+                    ..palette.text
+                },
+                ..rest
+            }
+        };
+
+        crate::gui::components::hover_fade(inner, rest, hover, self.animations_enabled).into()
     }
 }
 
@@ -216,6 +234,7 @@ impl App {
         let style = PickerStyle {
             alpha: progress,
             palette,
+            animations_enabled: self.config.ui.animations_enabled,
         };
 
         let mut items: Vec<Element<Message>> = Vec::new();

--- a/src/gui/components/button.rs
+++ b/src/gui/components/button.rs
@@ -1,34 +1,37 @@
+//! Button factories with built-in hover-fade animation.
+//!
+//! Every button rendered by the app should ultimately go through one of these
+//! factories so the hover transition stays visually consistent across screens.
+//! The button itself stays transparent; the animated background + border is
+//! painted behind it by [`hover_fade`].
+
+use crate::gui::app::Message;
+use crate::gui::components::{HoverStyle, hover_fade};
 use crate::gui::theme::Palette;
-use iced::widget::button;
-use iced::{Background, Border, Color, Shadow, Theme};
+use iced::widget::{button, text};
+use iced::{Background, Border, Color, Element, Length, Shadow, Theme};
 
 const RADIUS: f32 = 6.0;
+const ICON_RADIUS: f32 = 6.0;
+const MENU_RADIUS: f32 = 4.0;
 
-pub fn primary(text: &str, palette: Palette) -> button::Button<'_, crate::gui::app::Message> {
-    button(iced::widget::text(text).size(13))
+/// Accent-filled primary button (e.g. Save, confirm).
+pub fn primary<'a>(
+    label: impl AsRef<str>,
+    on_press: Message,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
+    let inner = button(text(label.as_ref().to_string()).size(13))
         .padding([7, 16])
-        .style(move |_theme: &Theme, status: button::Status| {
-            let bg = match status {
-                button::Status::Hovered => Color {
-                    r: palette.accent.r * 1.1,
-                    g: palette.accent.g * 1.1,
-                    b: palette.accent.b * 1.1,
-                    a: 1.0,
+        .on_press(on_press)
+        .style(
+            move |_theme: &Theme, status: button::Status| button::Style {
+                background: Some(Background::Color(Color::TRANSPARENT)),
+                text_color: match status {
+                    button::Status::Disabled => palette.text_secondary,
+                    _ => palette.background,
                 },
-                button::Status::Pressed => Color {
-                    a: 0.85,
-                    ..palette.accent
-                },
-                button::Status::Disabled => palette.surface,
-                _ => palette.accent,
-            };
-            let text_color = match status {
-                button::Status::Disabled => palette.text_secondary,
-                _ => palette.background,
-            };
-            button::Style {
-                background: Some(Background::Color(bg)),
-                text_color,
                 border: Border {
                     radius: RADIUS.into(),
                     width: 0.0,
@@ -36,55 +39,232 @@ pub fn primary(text: &str, palette: Palette) -> button::Button<'_, crate::gui::a
                 },
                 shadow: Shadow::default(),
                 snap: true,
-            }
-        })
+            },
+        );
+
+    let rest = HoverStyle {
+        background: palette.accent,
+        border_color: Color::TRANSPARENT,
+        border_width: 0.0,
+        radius: RADIUS,
+    };
+    let hover = HoverStyle {
+        background: Color {
+            r: (palette.accent.r * 1.1).clamp(0.0, 1.0),
+            g: (palette.accent.g * 1.1).clamp(0.0, 1.0),
+            b: (palette.accent.b * 1.1).clamp(0.0, 1.0),
+            a: 1.0,
+        },
+        ..rest
+    };
+
+    hover_fade(inner, rest, hover, animations_enabled).into()
 }
 
-pub fn secondary(text: &str, palette: Palette) -> button::Button<'_, crate::gui::app::Message> {
-    button(iced::widget::text(text).size(13))
+/// Surface-tinted secondary button (e.g. Cancel). If `on_press` is `None`
+/// the button is rendered in a disabled state.
+pub fn secondary<'a>(
+    label: impl AsRef<str>,
+    on_press: Option<Message>,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
+    let enabled = on_press.is_some();
+    let mut inner = button(text(label.as_ref().to_string()).size(13))
         .padding([7, 16])
-        .style(move |_theme: &Theme, status: button::Status| {
-            let (bg, border_alpha) = match status {
-                button::Status::Hovered => (
-                    Color {
-                        a: 0.12,
-                        ..palette.text
-                    },
-                    0.2,
-                ),
-                button::Status::Pressed => (
-                    Color {
-                        a: 0.08,
-                        ..palette.text
-                    },
-                    0.25,
-                ),
-                button::Status::Disabled => (
-                    Color {
-                        a: 0.04,
-                        ..palette.text
-                    },
-                    0.05,
-                ),
-                _ => (Color::TRANSPARENT, 0.1),
-            };
-            let text_color = match status {
-                button::Status::Disabled => palette.text_secondary,
-                _ => palette.text,
-            };
-            button::Style {
-                background: Some(Background::Color(bg)),
-                text_color,
+        .style(
+            move |_theme: &Theme, status: button::Status| button::Style {
+                background: Some(Background::Color(Color::TRANSPARENT)),
+                text_color: if enabled {
+                    match status {
+                        button::Status::Disabled => palette.text_secondary,
+                        _ => palette.text,
+                    }
+                } else {
+                    palette.text_secondary
+                },
                 border: Border {
                     radius: RADIUS.into(),
-                    width: 1.0,
-                    color: Color {
-                        a: border_alpha,
-                        ..palette.text
-                    },
+                    width: 0.0,
+                    color: Color::TRANSPARENT,
                 },
                 shadow: Shadow::default(),
                 snap: true,
+            },
+        );
+    if let Some(msg) = on_press {
+        inner = inner.on_press(msg);
+    }
+
+    let rest = HoverStyle {
+        background: Color::TRANSPARENT,
+        border_color: Color {
+            a: 0.1,
+            ..palette.text
+        },
+        border_width: 1.0,
+        radius: RADIUS,
+    };
+    let hover = if enabled {
+        HoverStyle {
+            background: Color {
+                a: 0.12,
+                ..palette.text
+            },
+            border_color: Color {
+                a: 0.2,
+                ..palette.text
+            },
+            border_width: 1.0,
+            radius: RADIUS,
+        }
+    } else {
+        rest
+    };
+
+    hover_fade(inner, rest, hover, animations_enabled).into()
+}
+
+/// Small glyph/icon button used for tab-bar controls, SSH row actions, etc.
+pub fn icon<'a>(
+    glyph: impl AsRef<str>,
+    on_press: Message,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
+    let inner = button(text(glyph.as_ref().to_string()).size(13))
+        .padding([6, 10])
+        .on_press(on_press)
+        .style(
+            move |_theme: &Theme, status: button::Status| button::Style {
+                background: Some(Background::Color(Color::TRANSPARENT)),
+                text_color: match status {
+                    button::Status::Hovered => palette.text,
+                    _ => palette.text_secondary,
+                },
+                border: Border {
+                    radius: ICON_RADIUS.into(),
+                    width: 0.0,
+                    color: Color::TRANSPARENT,
+                },
+                shadow: Shadow::default(),
+                snap: true,
+            },
+        );
+
+    let rest = HoverStyle {
+        background: Color::TRANSPARENT,
+        border_color: Color::TRANSPARENT,
+        border_width: 0.0,
+        radius: ICON_RADIUS,
+    };
+    let hover = HoverStyle {
+        background: Color {
+            a: 0.1,
+            ..palette.text
+        },
+        ..rest
+    };
+
+    hover_fade(inner, rest, hover, animations_enabled).into()
+}
+
+/// Same as [`icon`] but with an active/toggled state that keeps an accent
+/// background even when the cursor is not over the button (used by the SFTP
+/// toggle on the tab bar).
+pub fn icon_toggle<'a>(
+    glyph: impl AsRef<str>,
+    on_press: Message,
+    active: bool,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
+    let inner = button(text(glyph.as_ref().to_string()).size(13))
+        .padding([6, 10])
+        .on_press(on_press)
+        .style(
+            move |_theme: &Theme, status: button::Status| button::Style {
+                background: Some(Background::Color(Color::TRANSPARENT)),
+                text_color: if active {
+                    palette.accent
+                } else {
+                    match status {
+                        button::Status::Hovered => palette.text,
+                        _ => palette.text_secondary,
+                    }
+                },
+                border: Border {
+                    radius: ICON_RADIUS.into(),
+                    width: 0.0,
+                    color: Color::TRANSPARENT,
+                },
+                shadow: Shadow::default(),
+                snap: true,
+            },
+        );
+
+    let rest = HoverStyle {
+        background: if active {
+            Color {
+                a: 0.08,
+                ..palette.accent
             }
-        })
+        } else {
+            Color::TRANSPARENT
+        },
+        border_color: Color::TRANSPARENT,
+        border_width: 0.0,
+        radius: ICON_RADIUS,
+    };
+    let hover = HoverStyle {
+        background: Color {
+            a: 0.12,
+            ..palette.text
+        },
+        ..rest
+    };
+
+    hover_fade(inner, rest, hover, animations_enabled).into()
+}
+
+/// Full-width context-menu row.
+pub fn menu_item<'a>(
+    label: impl AsRef<str>,
+    on_press: Message,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
+    let inner = button(text(label.as_ref().to_string()).size(13))
+        .padding([7, 14])
+        .width(Length::Fill)
+        .on_press(on_press)
+        .style(
+            move |_theme: &Theme, _status: button::Status| button::Style {
+                background: Some(Background::Color(Color::TRANSPARENT)),
+                text_color: palette.text,
+                border: Border {
+                    radius: MENU_RADIUS.into(),
+                    width: 0.0,
+                    color: Color::TRANSPARENT,
+                },
+                shadow: Shadow::default(),
+                snap: false,
+            },
+        );
+
+    let rest = HoverStyle {
+        background: Color::TRANSPARENT,
+        border_color: Color::TRANSPARENT,
+        border_width: 0.0,
+        radius: MENU_RADIUS,
+    };
+    let hover = HoverStyle {
+        background: Color {
+            a: 0.1,
+            ..palette.text
+        },
+        ..rest
+    };
+
+    hover_fade(inner, rest, hover, animations_enabled).into()
 }

--- a/src/gui/components/context_menu.rs
+++ b/src/gui/components/context_menu.rs
@@ -1,6 +1,7 @@
 use crate::gui::app::Message;
+use crate::gui::components::menu_item;
 use crate::gui::theme::{Palette, RADIUS_SMALL};
-use iced::widget::{button, column, container, mouse_area, stack, text};
+use iced::widget::{column, container, mouse_area, stack, text};
 use iced::{Background, Border, Color, Element, Length, Padding};
 
 pub struct ContextMenuItem {
@@ -14,38 +15,11 @@ pub fn context_menu<'a>(
     position: iced::Point,
     on_dismiss: Message,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let menu_items: Vec<Element<Message>> = items
         .into_iter()
-        .map(|item| {
-            button(text(item.label).size(13))
-                .on_press(item.message)
-                .padding([7, 14])
-                .width(Length::Fill)
-                .style(
-                    move |_theme: &iced::Theme, status: button::Status| button::Style {
-                        background: Some(Background::Color(
-                            if matches!(status, button::Status::Hovered) {
-                                Color {
-                                    a: 0.1,
-                                    ..palette.text
-                                }
-                            } else {
-                                Color::TRANSPARENT
-                            },
-                        )),
-                        text_color: palette.text,
-                        border: Border {
-                            radius: RADIUS_SMALL.into(),
-                            width: 0.0,
-                            color: Color::TRANSPARENT,
-                        },
-                        shadow: iced::Shadow::default(),
-                        snap: false,
-                    },
-                )
-                .into()
-        })
+        .map(|item| menu_item(item.label, item.message, palette, animations_enabled))
         .collect();
 
     let menu = container(column(menu_items).padding([4, 4]))

--- a/src/gui/components/mod.rs
+++ b/src/gui/components/mod.rs
@@ -7,22 +7,7 @@ pub mod ime_wrapper;
 pub mod tab_bar;
 pub mod widget_styles;
 
-use crate::gui::theme::Palette;
-
-pub fn button_primary(
-    text: &str,
-    palette: Palette,
-) -> iced::widget::button::Button<'_, crate::gui::app::Message> {
-    button::primary(text, palette)
-}
-
-pub fn button_secondary(
-    text: &str,
-    palette: Palette,
-) -> iced::widget::button::Button<'_, crate::gui::app::Message> {
-    button::secondary(text, palette)
-}
-
+pub use button::{icon as button_icon, menu_item, primary, secondary};
 pub use category_transition::CategoryTransition;
 pub use container::panel;
 pub use hover_fade::{HoverStyle, hover_fade};

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -1,5 +1,5 @@
 use crate::gui::app::Message;
-use crate::gui::components::{HoverStyle, hover_fade};
+use crate::gui::components::{HoverStyle, button as button_factory, hover_fade};
 use crate::gui::theme::Palette;
 use iced::widget::mouse_area;
 use iced::widget::{button, container, row, scrollable, text};
@@ -61,109 +61,11 @@ pub fn tab_bar<'a>(
         tab_elements.push(tab_item.into());
     }
 
-    // Background is painted by `hover_fade` behind the button so it can
-    // cross-fade on hover; the button itself stays transparent.
-    let icon_style = move |_theme: &Theme, status: button::Status| button::Style {
-        background: Some(Background::Color(Color::TRANSPARENT)),
-        text_color: match status {
-            button::Status::Hovered => palette.text,
-            _ => palette.text_secondary,
-        },
-        border: Border {
-            radius: 6.0.into(),
-            width: 0.0,
-            color: Color::TRANSPARENT,
-        },
-        shadow: iced::Shadow::default(),
-        snap: true,
-    };
-    let icon_rest = HoverStyle {
-        background: Color::TRANSPARENT,
-        border_color: Color::TRANSPARENT,
-        border_width: 0.0,
-        radius: 6.0,
-    };
-    let icon_hover = HoverStyle {
-        background: Color {
-            a: 0.1,
-            ..palette.text
-        },
-        ..icon_rest
-    };
-
-    let add_btn = hover_fade(
-        button(text("+").size(13))
-            .on_press(on_add)
-            .padding([6, 10])
-            .style(icon_style),
-        icon_rest,
-        icon_hover,
-        animations_enabled,
-    );
-    let settings_btn = hover_fade(
-        button(text("\u{2699}").size(13))
-            .on_press(on_settings)
-            .padding([6, 10])
-            .style(icon_style),
-        icon_rest,
-        icon_hover,
-        animations_enabled,
-    );
+    let add_btn = button_factory::icon("+", on_add, palette, animations_enabled);
+    let settings_btn = button_factory::icon("\u{2699}", on_settings, palette, animations_enabled);
 
     let sftp_btn: Option<Element<Message>> = sftp_toggle.map(|(msg, active)| {
-        let label_color = if active {
-            palette.accent
-        } else {
-            palette.text_secondary
-        };
-        let sftp_style = move |_theme: &Theme, status: button::Status| button::Style {
-            background: Some(Background::Color(Color::TRANSPARENT)),
-            text_color: if active {
-                palette.accent
-            } else {
-                match status {
-                    button::Status::Hovered => palette.text,
-                    _ => label_color,
-                }
-            },
-            border: Border {
-                radius: 6.0.into(),
-                width: 0.0,
-                color: Color::TRANSPARENT,
-            },
-            shadow: iced::Shadow::default(),
-            snap: true,
-        };
-        let sftp_rest = HoverStyle {
-            background: if active {
-                Color {
-                    a: 0.08,
-                    ..palette.accent
-                }
-            } else {
-                Color::TRANSPARENT
-            },
-            border_color: Color::TRANSPARENT,
-            border_width: 0.0,
-            radius: 6.0,
-        };
-        let sftp_hover = HoverStyle {
-            background: Color {
-                a: 0.12,
-                ..palette.text
-            },
-            ..sftp_rest
-        };
-        hover_fade(
-            button(text("\u{21C5}").size(13))
-                .on_press(msg)
-                .padding([6, 10])
-                .style(sftp_style),
-            sftp_rest,
-            sftp_hover,
-            animations_enabled,
-        )
-        .into()
+        button_factory::icon_toggle("\u{21C5}", msg, active, palette, animations_enabled)
     });
 
     let tabs_row = row(tab_elements)
@@ -235,8 +137,8 @@ pub fn tab_bar<'a>(
     if let Some(btn) = sftp_btn {
         trailing.push(btn);
     }
-    trailing.push(add_btn.into());
-    trailing.push(settings_btn.into());
+    trailing.push(add_btn);
+    trailing.push(settings_btn);
 
     #[cfg(target_os = "windows")]
     let content = {

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -554,6 +554,7 @@ pub fn view_category<'a>(
     ssh_config_profiles: &'a [SshProfile],
     palette: Palette,
 ) -> Element<'a, Message> {
+    let animations_enabled = config.ui.animations_enabled;
     match category {
         SettingsCategory::Appearance => {
             let selected_font = all_font_options
@@ -571,7 +572,7 @@ pub fn view_category<'a>(
         SettingsCategory::Terminal => terminal::view(config, draft, palette),
         SettingsCategory::Theme => theme::view(config, draft, palette),
         SettingsCategory::Shortcuts => shortcuts::view(config, draft, palette),
-        SettingsCategory::Ssh => ssh::view(draft, ssh_config_profiles, palette),
+        SettingsCategory::Ssh => ssh::view(draft, ssh_config_profiles, palette, animations_enabled),
     }
 }
 

--- a/src/gui/settings/ssh.rs
+++ b/src/gui/settings/ssh.rs
@@ -1,32 +1,32 @@
 use crate::config::SshAuthMethod;
 use crate::gui::app::Message;
-use crate::gui::components::{button_primary, button_secondary};
+use crate::gui::components::{button_icon, primary, secondary};
 use crate::gui::settings::{
     SettingsDraft, SshConnectionTestStatus, SshProfileDraft, SshProfileField, SshProfileModalMode,
 };
 use crate::gui::theme::{Palette, RADIUS_NORMAL, RADIUS_SMALL, SPACING_NORMAL, SPACING_SMALL};
-use iced::widget::{
-    button, center, checkbox, column, container, mouse_area, row, stack, text, text_input,
-};
+use iced::widget::{center, checkbox, column, container, mouse_area, row, stack, text, text_input};
 use iced::{Alignment, Background, Border, Color, Element, Length};
 
 pub fn view<'a>(
     draft: &'a SettingsDraft,
     ssh_config_profiles: &'a [crate::config::SshProfile],
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
-    content(draft, ssh_config_profiles, palette)
+    content(draft, ssh_config_profiles, palette, animations_enabled)
 }
 
 pub fn modal_overlay<'a>(
     base: Element<'a, Message>,
     draft: &'a SettingsDraft,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     if let Some(index) = draft.ssh_profile_delete_pending
         && let Some(profile) = draft.ssh_profiles.get(index)
     {
-        return delete_confirm_overlay(base, profile, palette);
+        return delete_confirm_overlay(base, profile, palette, animations_enabled);
     }
 
     if let Some(mode) = draft.ssh_profile_modal_mode {
@@ -37,6 +37,7 @@ pub fn modal_overlay<'a>(
             draft.ssh_profiles_error.as_deref(),
             &draft.ssh_connection_test_status,
             palette,
+            animations_enabled,
         );
     }
 
@@ -47,6 +48,7 @@ fn delete_confirm_overlay<'a>(
     base: Element<'a, Message>,
     profile: &'a SshProfileDraft,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let backdrop = mouse_area(backdrop(palette)).on_press(Message::CancelRemoveSshProfile);
     let title = profile_title(profile);
@@ -60,10 +62,18 @@ fn delete_confirm_overlay<'a>(
             text(description).size(13).color(palette.text_secondary),
             row![
                 container("").width(Length::Fill),
-                button_secondary(crate::t!("settings.ssh.cancel"), palette)
-                    .on_press(Message::CancelRemoveSshProfile),
-                button_primary(crate::t!("settings.ssh.delete"), palette)
-                    .on_press(Message::ConfirmRemoveSshProfile),
+                secondary(
+                    crate::t!("settings.ssh.cancel"),
+                    Some(Message::CancelRemoveSshProfile),
+                    palette,
+                    animations_enabled,
+                ),
+                primary(
+                    crate::t!("settings.ssh.delete"),
+                    Message::ConfirmRemoveSshProfile,
+                    palette,
+                    animations_enabled,
+                ),
             ]
             .spacing(SPACING_SMALL)
             .align_y(Alignment::Center)
@@ -102,6 +112,7 @@ fn content<'a>(
     draft: &'a SettingsDraft,
     ssh_config_profiles: &'a [crate::config::SshProfile],
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let mut items: Vec<Element<Message>> = Vec::new();
 
@@ -111,7 +122,7 @@ fn content<'a>(
                 .size(16)
                 .color(palette.text),
             container("").width(Length::Fill),
-            button_primary("+", palette).on_press(Message::AddSshProfile),
+            primary("+", Message::AddSshProfile, palette, animations_enabled),
         ]
         .spacing(SPACING_SMALL)
         .align_y(Alignment::Center)
@@ -127,7 +138,7 @@ fn content<'a>(
         items.push(empty_state(palette));
     } else {
         for (index, profile) in draft.ssh_profiles.iter().enumerate() {
-            items.push(profile_row(index, profile, palette));
+            items.push(profile_row(index, profile, palette, animations_enabled));
         }
     }
 
@@ -145,7 +156,12 @@ fn content<'a>(
             .into(),
         );
         for (index, profile) in ssh_config_profiles.iter().enumerate() {
-            items.push(config_profile_row(index, profile, palette));
+            items.push(config_profile_row(
+                index,
+                profile,
+                palette,
+                animations_enabled,
+            ));
         }
     }
 
@@ -159,6 +175,7 @@ fn config_profile_row<'a>(
     index: usize,
     profile: &'a crate::config::SshProfile,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let title = if !profile.name.is_empty() {
         profile.name.clone()
@@ -189,9 +206,14 @@ fn config_profile_row<'a>(
             ]
             .spacing(4)
             .width(Length::Fill),
-            row![icon_button("\u{25b6}", palette).on_press(Message::CreateSshTabFromConfig(index)),]
-                .spacing(6)
-                .align_y(Alignment::Center),
+            row![button_icon(
+                "\u{25b6}",
+                Message::CreateSshTabFromConfig(index),
+                palette,
+                animations_enabled,
+            ),]
+            .spacing(6)
+            .align_y(Alignment::Center),
         ]
         .spacing(SPACING_NORMAL)
         .align_y(Alignment::Center)
@@ -246,6 +268,7 @@ fn profile_row<'a>(
     index: usize,
     profile: &'a SshProfileDraft,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let title = profile_title(profile);
     let subtitle = profile_subtitle(profile);
@@ -259,9 +282,24 @@ fn profile_row<'a>(
             .spacing(4)
             .width(Length::Fill),
             row![
-                icon_button("\u{25b6}", palette).on_press(Message::CreateSshTab(index)),
-                icon_button("\u{270e}", palette).on_press(Message::EditSshProfile(index)),
-                icon_button("\u{1f5d1}", palette).on_press(Message::RequestRemoveSshProfile(index)),
+                button_icon(
+                    "\u{25b6}",
+                    Message::CreateSshTab(index),
+                    palette,
+                    animations_enabled,
+                ),
+                button_icon(
+                    "\u{270e}",
+                    Message::EditSshProfile(index),
+                    palette,
+                    animations_enabled,
+                ),
+                button_icon(
+                    "\u{1f5d1}",
+                    Message::RequestRemoveSshProfile(index),
+                    palette,
+                    animations_enabled,
+                ),
             ]
             .spacing(6)
             .align_y(Alignment::Center),
@@ -334,6 +372,7 @@ fn empty_label(value: &str) -> &str {
     if value.is_empty() { "-" } else { value }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn modal_overlay_content<'a>(
     base: Element<'a, Message>,
     mode: SshProfileModalMode,
@@ -341,6 +380,7 @@ fn modal_overlay_content<'a>(
     error: Option<&'a str>,
     test_status: &'a SshConnectionTestStatus,
     palette: Palette,
+    animations_enabled: bool,
 ) -> Element<'a, Message> {
     let backdrop = mouse_area(backdrop(palette)).on_press(Message::CloseSshProfileModal);
 
@@ -354,7 +394,12 @@ fn modal_overlay_content<'a>(
         row![
             text(title).size(16).color(palette.text),
             container("").width(Length::Fill),
-            icon_button("x", palette).on_press(Message::CloseSshProfileModal),
+            button_icon(
+                "x",
+                Message::CloseSshProfileModal,
+                palette,
+                animations_enabled
+            ),
         ]
         .align_y(Alignment::Center)
         .width(Length::Fill)
@@ -365,25 +410,42 @@ fn modal_overlay_content<'a>(
     {
         modal_items.push(status_banner(error, palette));
     }
-    modal_items.push(profile_form(profile, palette));
+    modal_items.push(profile_form(profile, palette, animations_enabled));
     if let Some(status) = connection_test_status_banner(test_status, palette) {
         modal_items.push(status);
     }
-    let test_button = if matches!(test_status, SshConnectionTestStatus::Testing) {
-        button_secondary(crate::t!("settings.ssh.testing"), palette)
+    let test_button: Element<Message> = if matches!(test_status, SshConnectionTestStatus::Testing) {
+        secondary(
+            crate::t!("settings.ssh.testing"),
+            None,
+            palette,
+            animations_enabled,
+        )
     } else {
-        button_secondary(crate::t!("settings.ssh.test_connection"), palette)
-            .on_press(Message::TestSshConnection)
+        secondary(
+            crate::t!("settings.ssh.test_connection"),
+            Some(Message::TestSshConnection),
+            palette,
+            animations_enabled,
+        )
     };
     modal_items.push(container("").height(Length::Fixed(8.0)).into());
     modal_items.push(
         row![
             test_button,
             container("").width(Length::Fill),
-            button_secondary(crate::t!("settings.ssh.cancel"), palette)
-                .on_press(Message::CloseSshProfileModal),
-            button_primary(crate::t!("settings.ssh.save"), palette)
-                .on_press(Message::SaveSshProfileModal),
+            secondary(
+                crate::t!("settings.ssh.cancel"),
+                Some(Message::CloseSshProfileModal),
+                palette,
+                animations_enabled,
+            ),
+            primary(
+                crate::t!("settings.ssh.save"),
+                Message::SaveSshProfileModal,
+                palette,
+                animations_enabled,
+            ),
         ]
         .spacing(SPACING_SMALL)
         .align_y(Alignment::Center)
@@ -452,12 +514,17 @@ fn backdrop(palette: Palette) -> container::Container<'static, Message> {
         })
 }
 
-fn profile_form<'a>(profile: &'a SshProfileDraft, palette: Palette) -> Element<'a, Message> {
+fn profile_form<'a>(
+    profile: &'a SshProfileDraft,
+    palette: Palette,
+    animations_enabled: bool,
+) -> Element<'a, Message> {
     let key_button = auth_method_button(
         crate::t!("settings.ssh.key_file_label"),
         matches!(profile.auth_method, SshAuthMethod::KeyFile),
         "key_file",
         palette,
+        animations_enabled,
     );
 
     let password_button = auth_method_button(
@@ -465,6 +532,7 @@ fn profile_form<'a>(profile: &'a SshProfileDraft, palette: Palette) -> Element<'
         matches!(profile.auth_method, SshAuthMethod::Password),
         "password",
         palette,
+        animations_enabled,
     );
 
     let auth_input: Element<'a, Message> = if matches!(profile.auth_method, SshAuthMethod::KeyFile)
@@ -595,12 +663,13 @@ fn auth_method_button<'a>(
     selected: bool,
     value: &'static str,
     palette: Palette,
-) -> button::Button<'a, Message> {
+    animations_enabled: bool,
+) -> Element<'a, Message> {
     let message = Message::SshProfileModalFieldChanged(SshProfileField::AuthMethod, value.into());
     if selected {
-        button_primary(label, palette).on_press(message)
+        primary(label, message, palette, animations_enabled)
     } else {
-        button_secondary(label, palette).on_press(message)
+        secondary(label, Some(message), palette, animations_enabled)
     }
 }
 
@@ -627,55 +696,6 @@ fn status_banner<'a>(message: &'a str, palette: Palette) -> Element<'a, Message>
             ..Default::default()
         })
         .into()
-}
-
-fn icon_button(icon: &str, palette: Palette) -> button::Button<'_, Message> {
-    button(text(icon).size(15)).padding([5, 8]).style(
-        move |_theme: &iced::Theme, status: button::Status| {
-            let (bg, border_alpha) = match status {
-                button::Status::Hovered => (
-                    Color {
-                        a: 0.12,
-                        ..palette.text
-                    },
-                    0.20,
-                ),
-                button::Status::Pressed => (
-                    Color {
-                        a: 0.08,
-                        ..palette.text
-                    },
-                    0.25,
-                ),
-                button::Status::Disabled => (
-                    Color {
-                        a: 0.04,
-                        ..palette.text
-                    },
-                    0.05,
-                ),
-                _ => (Color::TRANSPARENT, 0.10),
-            };
-            let text_color = match status {
-                button::Status::Disabled => palette.text_secondary,
-                _ => palette.text,
-            };
-            button::Style {
-                background: Some(Background::Color(bg)),
-                text_color,
-                border: Border {
-                    radius: RADIUS_SMALL.into(),
-                    width: 1.0,
-                    color: Color {
-                        a: border_alpha,
-                        ..palette.text
-                    },
-                },
-                shadow: iced::Shadow::default(),
-                snap: true,
-            }
-        },
-    )
 }
 
 fn modal_input<'a, F>(


### PR DESCRIPTION
Closes #154.

모든 버튼에 hover_fade를 일관되게 적용하기 위해 `components/button.rs`에 hover_fade 빌트인 factory를 추가하고 호출 사이트를 마이그레이션.

## 신규 factory
- `primary(label, on_press, palette, anims)` — accent 채움
- `secondary(label, on_press: Option, palette, anims)` — None이면 disabled
- `icon(glyph, on_press, palette, anims)` — 표준 아이콘 버튼
- `icon_toggle(glyph, on_press, active, palette, anims)` — SFTP 같은 active 토글
- `menu_item(label, on_press, palette, anims)` — context menu

## 마이그레이션
- `ssh.rs`: 9 + 4 icon row actions (로컬 `icon_button` 제거)
- `tab_bar.rs`: add/settings/sftp 컨트롤 버튼 → factory (close는 active styling 때문에 수동 유지)
- `dialog.rs`, `context_menu.rs`, `view/mod.rs` lobby, `shell_picker.rs`: factory 또는 hover_fade 적용
- `sftp.rs`: header 버튼 + 모든 row → hover_fade
- 진입점에 `animations_enabled` 전파 (`confirm_dialog`, `context_menu`, `ssh::view`, `sftp::drawer` 등)

## 수동 유지 사이트
preset 카드 / segmented button / 활성 탭 / 윈도우 컨트롤 등 — 일반 factory에 안 맞는 특수 스타일들. 모두 동일한 `hover_fade` 래퍼는 거쳐서 동작 일관성은 확보.

build / clippy / test(--lib, 54 passed) / fmt 모두 통과.