### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,7 +3775,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rabbitty"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ab_glyph",
  "alacritty_terminal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rabbitty"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["neverprogrammer@gmail.com"]
 rust-version = "1.92"
@@ -83,7 +83,7 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 name = "Rabbitty"
 identifier = "io.github.rabbitty"
 icon = ["assets/icon.icns"]
-version = "0.1.1"
+version = "0.1.2"
 copyright = "Copyright 2026 RabbiTTY contributors"
 category = "public.app-category.utilities"
 short_description = "Fast, lean terminal emulator."


### PR DESCRIPTION
0.1.1 → 0.1.2 릴리스 준비.

머지 후 main에서 v0.1.2 태그 → Release 워크플로 수동 trigger.