### PR TITLE
feat: terminal right-click action setting + paste modal i18n/keyboard

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -10,6 +10,14 @@ default = "Default"
 [context_menu]
 duplicate = "Duplicate"
 close = "Close"
+paste = "Paste"
+copy = "Copy"
+
+[dialog]
+paste_multiline_title = "Paste multiple lines?"
+paste_multiline_body = "This will paste {count} lines."
+paste = "Paste"
+cancel = "Cancel"
 
 [lobby]
 new_tab = "New Tab"
@@ -58,6 +66,8 @@ shape = "Shape"
 blink = "Blink"
 bell_section = "Bell"
 behavior = "Behavior"
+mouse_section = "Mouse"
+right_click = "Right-click"
 
 [settings.terminal.cursor_shape]
 block = "Block"
@@ -68,6 +78,11 @@ underline = "Underline"
 off = "Off"
 visual = "Visual flash"
 sound = "Sound"
+
+[settings.terminal.right_click_action]
+paste = "Paste"
+menu = "Menu"
+none = "None"
 
 [settings.theme]
 color_scheme_section = "Color Scheme"

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -10,6 +10,14 @@ default = "기본"
 [context_menu]
 duplicate = "복제"
 close = "닫기"
+paste = "붙여넣기"
+copy = "복사"
+
+[dialog]
+paste_multiline_title = "여러 줄을 붙여넣을까요?"
+paste_multiline_body = "{count}개의 줄을 붙여넣습니다."
+paste = "붙여넣기"
+cancel = "취소"
 
 [lobby]
 new_tab = "새 탭"
@@ -58,6 +66,8 @@ shape = "모양"
 blink = "깜빡임"
 bell_section = "벨"
 behavior = "동작"
+mouse_section = "마우스"
+right_click = "우클릭"
 
 [settings.terminal.cursor_shape]
 block = "블록"
@@ -68,6 +78,11 @@ underline = "밑줄"
 off = "끔"
 visual = "시각적 플래시"
 sound = "소리"
+
+[settings.terminal.right_click_action]
+paste = "붙여넣기"
+menu = "메뉴"
+none = "없음"
 
 [settings.theme]
 color_scheme_section = "색 구성표"

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,6 +132,31 @@ impl std::fmt::Display for BellMode {
     }
 }
 
+/// Action taken when the terminal area is right-clicked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RightClickAction {
+    #[default]
+    Paste,
+    Menu,
+    None,
+}
+
+impl RightClickAction {
+    pub const ALL: [Self; 3] = [Self::Paste, Self::Menu, Self::None];
+}
+
+impl std::fmt::Display for RightClickAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::Paste => crate::t!("settings.terminal.right_click_action.paste"),
+            Self::Menu => crate::t!("settings.terminal.right_click_action.menu"),
+            Self::None => crate::t!("settings.terminal.right_click_action.none"),
+        };
+        f.write_str(label)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SshProfile {
     pub name: String,
@@ -193,6 +218,7 @@ pub struct TerminalConfig {
     pub cursor_shape: CursorShape,
     pub cursor_blink: bool,
     pub bell_mode: BellMode,
+    pub right_click_action: RightClickAction,
 }
 
 #[derive(Debug, Clone)]
@@ -266,6 +292,7 @@ struct TerminalFileConfig {
     cursor_shape: Option<CursorShape>,
     cursor_blink: Option<bool>,
     bell_mode: Option<BellMode>,
+    right_click_action: Option<RightClickAction>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -330,6 +357,7 @@ pub struct AppConfigUpdates {
     pub terminal_cursor_shape: Option<CursorShape>,
     pub terminal_cursor_blink: Option<bool>,
     pub terminal_bell_mode: Option<BellMode>,
+    pub terminal_right_click_action: Option<RightClickAction>,
 }
 
 impl Default for AppConfig {
@@ -356,6 +384,7 @@ impl Default for AppConfig {
                 cursor_shape: CursorShape::default(),
                 cursor_blink: DEFAULT_CURSOR_BLINK,
                 bell_mode: BellMode::default(),
+                right_click_action: RightClickAction::default(),
             },
             theme: ThemeConfig {
                 color_scheme: "Catppuccin Mocha".to_string(),
@@ -455,6 +484,9 @@ impl AppConfig {
         }
         if let Some(mode) = updates.terminal_bell_mode {
             self.terminal.bell_mode = mode;
+        }
+        if let Some(action) = updates.terminal_right_click_action {
+            self.terminal.right_click_action = action;
         }
         if let Some(scheme) = updates.color_scheme {
             self.theme.color_scheme = scheme;
@@ -594,6 +626,9 @@ impl AppConfig {
             }
             if let Some(mode) = term.bell_mode {
                 self.terminal.bell_mode = mode;
+            }
+            if let Some(action) = term.right_click_action {
+                self.terminal.right_click_action = action;
             }
         }
 
@@ -943,6 +978,7 @@ impl From<&AppConfig> for FileConfig {
                 cursor_shape: Some(config.terminal.cursor_shape),
                 cursor_blink: Some(config.terminal.cursor_blink),
                 bell_mode: Some(config.terminal.bell_mode),
+                right_click_action: Some(config.terminal.right_click_action),
             }),
             theme: Some(ThemeFileConfig {
                 color_scheme: if config.theme.color_scheme.is_empty() {

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -41,6 +41,7 @@ pub enum Message {
     SettingsCursorShapeSelected(crate::config::CursorShape),
     SettingsCursorBlinkToggled(bool),
     SettingsBellModeSelected(crate::config::BellMode),
+    SettingsRightClickActionSelected(crate::config::RightClickAction),
     AddSshProfile,
     EditSshProfile(usize),
     RequestRemoveSshProfile(usize),
@@ -99,6 +100,10 @@ pub enum Message {
     CreateSshTabFromConfig(usize),
     ShowTabContextMenu(usize),
     CloseTabContextMenu,
+    TerminalRightClick,
+    CloseTerminalContextMenu,
+    TerminalContextPaste,
+    TerminalContextCopy,
     CursorMoved(iced::Point),
     #[cfg(target_os = "macos")]
     ConfirmRestartForBlur,
@@ -193,6 +198,8 @@ pub struct App {
     pub(super) session_history: SessionHistory,
     pub(super) window_style_applied: bool,
     pub(super) tab_context_menu: Option<usize>,
+    /// Whether the terminal right-click context menu is currently shown.
+    pub(super) terminal_context_menu: bool,
     pub(super) cursor_position: iced::Point,
     #[cfg(target_os = "macos")]
     pub(super) show_restart_confirm: bool,
@@ -282,6 +289,7 @@ impl App {
             session_history: SessionHistory::load(),
             palette,
             tab_context_menu: None,
+            terminal_context_menu: false,
             cursor_position: iced::Point::ORIGIN,
             ime_active: false,
             ime_preedit: None,

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -338,8 +338,38 @@ impl App {
             Message::CloseTabContextMenu => {
                 self.tab_context_menu = None;
             }
+            Message::TerminalRightClick => {
+                use crate::config::RightClickAction;
+                match self.config.terminal.right_click_action {
+                    RightClickAction::Paste => {
+                        return iced::clipboard::read()
+                            .map(|content| Message::PasteClipboard(content.unwrap_or_default()));
+                    }
+                    RightClickAction::Menu => {
+                        self.terminal_context_menu = true;
+                    }
+                    RightClickAction::None => {}
+                }
+            }
+            Message::CloseTerminalContextMenu => {
+                self.terminal_context_menu = false;
+            }
+            Message::TerminalContextPaste => {
+                self.terminal_context_menu = false;
+                return iced::clipboard::read()
+                    .map(|content| Message::PasteClipboard(content.unwrap_or_default()));
+            }
+            Message::TerminalContextCopy => {
+                self.terminal_context_menu = false;
+                if let Some(tab) = self.tabs.get_mut(self.active_tab)
+                    && let Some(text) = tab.selected_text()
+                {
+                    tab.clear_selection();
+                    return iced::clipboard::write(text);
+                }
+            }
             Message::CursorMoved(point) => {
-                if self.tab_context_menu.is_none() {
+                if self.tab_context_menu.is_none() && !self.terminal_context_menu {
                     self.cursor_position = point;
                 }
             }
@@ -477,6 +507,10 @@ impl App {
             }
             Message::SettingsBellModeSelected(mode) => {
                 self.settings_draft.bell_mode = mode;
+                return self.apply_settings(true);
+            }
+            Message::SettingsRightClickActionSelected(action) => {
+                self.settings_draft.right_click_action = action;
                 return self.apply_settings(true);
             }
             Message::FontSelected(option) => {
@@ -732,6 +766,17 @@ impl App {
         modifiers: iced::keyboard::Modifiers,
         text: Option<String>,
     ) -> Task<Message> {
+        // The multi-line paste confirmation is the topmost overlay; while it is
+        // shown, Enter confirms, Escape cancels, and all other keys are swallowed.
+        if self.pending_paste.is_some() {
+            match key {
+                Key::Named(Named::Enter) => return self.update(Message::ConfirmMultilinePaste),
+                Key::Named(Named::Escape) => return self.update(Message::CancelMultilinePaste),
+                _ => {}
+            }
+            return Task::none();
+        }
+
         if self.show_shell_picker {
             match key {
                 Key::Named(Named::Escape) => {

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -107,19 +107,20 @@ impl App {
 
         if let Some(text) = self.pending_paste.as_deref() {
             let line_count = text.lines().count().max(1);
-            let description = format!("This will paste {} lines.", line_count);
+            let description =
+                t!("dialog.paste_multiline_body").replace("{count}", &line_count.to_string());
             return confirm_dialog(
                 base_layout,
-                "Paste multiple lines?",
+                t!("dialog.paste_multiline_title"),
                 &description,
                 vec![
                     DialogButton {
-                        label: "Cancel".into(),
+                        label: t!("dialog.cancel").into(),
                         message: Message::CancelMultilinePaste,
                         primary: false,
                     },
                     DialogButton {
-                        label: "Paste".into(),
+                        label: t!("dialog.paste").into(),
                         message: Message::ConfirmMultilinePaste,
                         primary: true,
                     },
@@ -140,6 +141,10 @@ impl App {
 
         if let Some(tab_index) = self.tab_context_menu {
             return self.view_tab_context_menu(base_layout, tab_index);
+        }
+
+        if self.terminal_context_menu {
+            return self.view_terminal_context_menu(base_layout);
         }
 
         base_layout.into()
@@ -431,6 +436,38 @@ impl App {
             ],
             self.cursor_position,
             Message::CloseTabContextMenu,
+            self.palette,
+            self.config.ui.animations_enabled,
+        )
+    }
+
+    fn view_terminal_context_menu<'a>(
+        &'a self,
+        base_layout: impl Into<Element<'a, Message>>,
+    ) -> Element<'a, Message> {
+        let has_selection = self
+            .tabs
+            .get(self.active_tab)
+            .and_then(|tab| tab.selected_text())
+            .is_some();
+
+        let mut items = Vec::new();
+        if has_selection {
+            items.push(ContextMenuItem {
+                label: t!("context_menu.copy"),
+                message: Message::TerminalContextCopy,
+            });
+        }
+        items.push(ContextMenuItem {
+            label: t!("context_menu.paste"),
+            message: Message::TerminalContextPaste,
+        });
+
+        context_menu(
+            base_layout,
+            items,
+            self.cursor_position,
+            Message::CloseTerminalContextMenu,
             self.palette,
             self.config.ui.animations_enabled,
         )

--- a/src/gui/render/mod.rs
+++ b/src/gui/render/mod.rs
@@ -104,6 +104,11 @@ impl ShaderProgram<Message> for TerminalProgram {
                     return Some(Action::publish(Message::SelectionChanged(None)).and_capture());
                 }
             }
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Right)) => {
+                if cursor.is_over(bounds) {
+                    return Some(Action::publish(Message::TerminalRightClick).and_capture());
+                }
+            }
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 // Use the absolute cursor position while dragging so the selection
                 // still extends after the cursor leaves the terminal bounds.

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -1,5 +1,6 @@
 use crate::config::{
-    AppConfig, AppConfigUpdates, BellMode, CursorShape, SshAuthMethod, SshProfile, parse_hex_color,
+    AppConfig, AppConfigUpdates, BellMode, CursorShape, RightClickAction, SshAuthMethod,
+    SshProfile, parse_hex_color,
 };
 use crate::gui::app::Message;
 use crate::gui::components::accent_toggler_style;
@@ -223,6 +224,7 @@ pub struct SettingsDraft {
     pub cursor_shape: CursorShape,
     pub cursor_blink: bool,
     pub bell_mode: BellMode,
+    pub right_click_action: RightClickAction,
     pub color_scheme: String,
     pub foreground: String,
     pub background: String,
@@ -264,6 +266,7 @@ impl SettingsDraft {
             cursor_shape: config.terminal.cursor_shape,
             cursor_blink: config.terminal.cursor_blink,
             bell_mode: config.terminal.bell_mode,
+            right_click_action: config.terminal.right_click_action,
             color_scheme: config.theme.color_scheme.clone(),
             foreground: format_rgb(config.theme.foreground),
             background: format_rgb(config.theme.background),
@@ -483,6 +486,7 @@ impl SettingsDraft {
             terminal_cursor_shape: Some(self.cursor_shape),
             terminal_cursor_blink: Some(self.cursor_blink),
             terminal_bell_mode: Some(self.bell_mode),
+            terminal_right_click_action: Some(self.right_click_action),
             color_scheme: Some(self.color_scheme.clone()),
             foreground: parse_hex_color(&self.foreground),
             background: parse_hex_color(&self.background),

--- a/src/gui/settings/terminal.rs
+++ b/src/gui/settings/terminal.rs
@@ -1,4 +1,4 @@
-use crate::config::{AppConfig, BellMode, CursorShape};
+use crate::config::{AppConfig, BellMode, CursorShape, RightClickAction};
 use crate::gui::app::Message;
 use crate::gui::components::accent_toggler_style;
 use crate::gui::settings::{
@@ -133,11 +133,32 @@ pub fn view<'a>(
         palette,
     );
 
+    let mouse_section = section(
+        crate::t!("settings.terminal.mouse_section"),
+        segmented_control(
+            crate::t!("settings.terminal.right_click"),
+            RightClickAction::ALL
+                .iter()
+                .map(|&action| {
+                    (
+                        right_click_action_label(action),
+                        Message::SettingsRightClickActionSelected(action),
+                        draft.right_click_action == action,
+                    )
+                })
+                .collect(),
+            palette,
+            config.ui.animations_enabled,
+        ),
+        palette,
+    );
+
     column(vec![
         scrollback_section,
         paste_section,
         cursor_section,
         bell_section,
+        mouse_section,
     ])
     .spacing(SPACING_NORMAL)
     .width(Length::Fill)
@@ -158,5 +179,13 @@ fn bell_mode_label(mode: BellMode) -> &'static str {
         BellMode::Off => crate::t!("settings.terminal.bell_mode.off"),
         BellMode::Visual => crate::t!("settings.terminal.bell_mode.visual"),
         BellMode::Sound => crate::t!("settings.terminal.bell_mode.sound"),
+    }
+}
+
+fn right_click_action_label(action: RightClickAction) -> &'static str {
+    match action {
+        RightClickAction::Paste => crate::t!("settings.terminal.right_click_action.paste"),
+        RightClickAction::Menu => crate::t!("settings.terminal.right_click_action.menu"),
+        RightClickAction::None => crate::t!("settings.terminal.right_click_action.none"),
     }
 }


### PR DESCRIPTION
Closes #159.

## 1. 우클릭 동작 설정 (신규)
- `RightClickAction` enum: Paste(기본) / Menu / None
- config plumbing + Terminal 설정에 "Mouse" 세그먼트 컨트롤 + i18n
- shader `update`에서 우클릭 감지 → `Message::TerminalRightClick`
- Paste = 클립보드 즉시 붙여넣기(멀티라인 확인 경유) / Menu = 컨텍스트 메뉴(Paste + 선택 시 Copy) / None
- 터미널 context_menu (Paste/Copy) + i18n (`context_menu.paste/copy`)

## 2. 붙여넣기 컨펌 모달 i18n
- title/body/buttons → `t!`. body는 `{count}` placeholder replace로 로케일별 어순 대응
- `[dialog]` 테이블 추가 (en/ko)

## 3. 컨펌 모달 Enter/Esc
- `pending_paste` 떠있을 때 Enter=확인, Esc=취소, 그 외 키 무시

build / clippy / test(--lib, 54 passed) / fmt 모두 통과.