### PR TITLE
fix: scale cell/selection background alpha by window opacity

### DIFF
--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -182,6 +182,7 @@ impl App {
             cursor_shape: self.config.terminal.cursor_shape,
             cursor_visible,
             cursor_color: active_tab.cursor_color(),
+            background_opacity: self.config.theme.background_opacity,
         }
         .widget()
         .width(Length::Fill)

--- a/src/gui/render/bg.rs
+++ b/src/gui/render/bg.rs
@@ -183,6 +183,7 @@ impl BackgroundPipeline {
         cursor: Option<[u32; 2]>,
         cursor_shape: CursorShape,
         cursor_color: [f32; 4],
+        background_opacity: f32,
     ) {
         self.instances.clear();
         let needed = cells.len().saturating_sub(self.instances.capacity());
@@ -190,12 +191,14 @@ impl BackgroundPipeline {
             self.instances.reserve(needed);
         }
         self.instances.extend(cells.iter().map(|cell| {
-            let bg = if selection.is_some_and(|s| s.contains_at(cell.row, cell.col, display_offset))
-            {
-                super::SELECTION_BG
-            } else {
-                cell.bg
-            };
+            let mut bg =
+                if selection.is_some_and(|s| s.contains_at(cell.row, cell.col, display_offset)) {
+                    super::SELECTION_BG
+                } else {
+                    cell.bg
+                };
+            // Keep colored backgrounds as translucent as the rest of the window.
+            bg[3] *= background_opacity;
             InstanceRaw {
                 pos: [cell.col as u32, cell.row as u32],
                 rect_offset: [0.0, 0.0],

--- a/src/gui/render/mod.rs
+++ b/src/gui/render/mod.rs
@@ -32,6 +32,7 @@ pub struct TerminalProgram {
     pub cursor_shape: crate::config::CursorShape,
     pub cursor_visible: bool,
     pub cursor_color: [f32; 4],
+    pub background_opacity: f32,
 }
 
 impl TerminalProgram {
@@ -325,6 +326,7 @@ impl ShaderProgram<Message> for TerminalProgram {
             cursor_shape: self.cursor_shape,
             cursor_visible: self.cursor_visible,
             cursor_color: self.cursor_color,
+            background_opacity: self.background_opacity,
         }
     }
 
@@ -359,6 +361,7 @@ pub struct TerminalPipeline {
     last_cursor_shape: crate::config::CursorShape,
     last_cursor_visible: bool,
     last_cursor_color: [f32; 4],
+    last_background_opacity: f32,
 }
 
 impl Pipeline for TerminalPipeline {
@@ -379,6 +382,7 @@ impl Pipeline for TerminalPipeline {
             last_cursor_shape: crate::config::CursorShape::Block,
             last_cursor_visible: false,
             last_cursor_color: [0.0; 4],
+            last_background_opacity: 1.0,
         }
     }
 }
@@ -398,6 +402,7 @@ pub struct TerminalPrimitive {
     cursor_shape: crate::config::CursorShape,
     cursor_visible: bool,
     cursor_color: [f32; 4],
+    background_opacity: f32,
 }
 
 impl Primitive for TerminalPrimitive {
@@ -436,7 +441,8 @@ impl Primitive for TerminalPrimitive {
             && self.cursor == pipeline.last_cursor
             && self.cursor_shape == pipeline.last_cursor_shape
             && self.cursor_visible == pipeline.last_cursor_visible
-            && self.cursor_color == pipeline.last_cursor_color;
+            && self.cursor_color == pipeline.last_cursor_color
+            && self.background_opacity == pipeline.last_background_opacity;
 
         if unchanged {
             return;
@@ -454,6 +460,7 @@ impl Primitive for TerminalPrimitive {
         pipeline.last_cursor_shape = self.cursor_shape;
         pipeline.last_cursor_visible = self.cursor_visible;
         pipeline.last_cursor_color = self.cursor_color;
+        pipeline.last_background_opacity = self.background_opacity;
 
         let cells = self.cells.as_slice();
 
@@ -472,6 +479,7 @@ impl Primitive for TerminalPrimitive {
             active_cursor,
             self.cursor_shape,
             self.cursor_color,
+            self.background_opacity,
         );
 
         pipeline


### PR DESCRIPTION
Closes #165.

반투명 창에서 색배경 셀·선택 영역이 불투명 사각형(double-alpha)으로 떠 보이던 문제 수정.

## 변경
- `bg.rs prepare_instances`: 셀/선택 배경 alpha에 `background_opacity` 곱함 (빈 셀 alpha 0은 그대로, 색배경·선택은 창과 같은 투명도)
- `background_opacity`를 `TerminalProgram` → `TerminalPrimitive` → `prepare_instances`로 전달, `unchanged` 캐시 체크에 포함
- 커서는 가시성 위해 불투명 유지
- opacity 1.0(불투명 창)이면 동작 변화 없음

## 한계
패널과의 이중 합성으로 색배경이 빈 영역보다 약간 더 진할 수 있음 — 불투명 섬은 제거됨. 완전 균일(특히 vim 등 전체 색배경 앱)은 composite 전역 opacity 리팩토링이 필요하며 별도 과제.

build / clippy / test(--lib, 54 passed) / fmt 모두 통과.