### PR TITLE
fix: sync scrollbar and honor scroll-speed config during drag autoscroll

### DIFF
--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -887,6 +887,7 @@ impl App {
             return Task::none();
         }
         let col = self.selection_autoscroll_col;
+        let step = (self.config.terminal.scroll_multiplier.round() as i32).max(1);
         let offset = {
             let Some(tab) = self.tabs.get_mut(self.active_tab) else {
                 self.selection_autoscroll = None;
@@ -897,7 +898,7 @@ impl App {
                 return Task::none();
             };
             let lines = tab.size().lines;
-            tab.scroll(if up { 1 } else { -1 });
+            tab.scroll(if up { step } else { -step });
             let (offset, _) = tab.scroll_position();
             let edge_row = if up {
                 0i64
@@ -914,7 +915,7 @@ impl App {
         };
         self.scroll_follow_bottom = offset == 0;
         self.ignore_scrollable_sync = IGNORE_SCROLL_SYNC_COUNT;
-        self.sync_terminal_scrollable()
+        self.sync_terminal_scrollable_forced()
     }
 
     fn perform_paste(&mut self, text: String) {


### PR DESCRIPTION
Closes #167. #163 후속.

## 변경 (`advance_selection_autoscroll`)
- 스크롤바 동기화: no-op `sync_terminal_scrollable()` → 실제 snap하는 `sync_terminal_scrollable_forced()` (휠 스크롤과 동일)
- 스크롤 속도: 고정 1줄/틱 → `config.terminal.scroll_multiplier` 반영 (`round().max(1)` 줄/틱)

build / clippy / test(--lib, 54 passed) / fmt 모두 통과.