### PR TITLE
feat: configurable tab bar position (top/bottom)

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -42,6 +42,12 @@ auto = "Auto"
 [settings.appearance]
 animations_section = "Animations"
 animations = "Enable animations"
+tabs_section = "Tabs"
+position = "Position"
+
+[settings.appearance.tab_position]
+top = "Top"
+bottom = "Bottom"
 
 [settings.terminal]
 font_section = "Font"

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -42,6 +42,12 @@ auto = "자동"
 [settings.appearance]
 animations_section = "애니메이션"
 animations = "애니메이션 사용"
+tabs_section = "탭"
+position = "위치"
+
+[settings.appearance.tab_position]
+top = "위"
+bottom = "아래"
 
 [settings.terminal]
 font_section = "글꼴"

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,6 +132,19 @@ impl std::fmt::Display for BellMode {
     }
 }
 
+/// Where the tab bar (which doubles as the title bar) is anchored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TabBarPosition {
+    #[default]
+    Top,
+    Bottom,
+}
+
+impl TabBarPosition {
+    pub const ALL: [Self; 2] = [Self::Top, Self::Bottom];
+}
+
 /// Action taken when the terminal area is right-clicked.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -201,6 +214,8 @@ pub struct UiConfig {
     pub language: Option<String>,
     /// Whether smooth hover transition animations are enabled.
     pub animations_enabled: bool,
+    /// Where the tab bar / title bar is anchored.
+    pub tab_bar_position: TabBarPosition,
 }
 
 #[derive(Debug, Clone)]
@@ -273,6 +288,7 @@ struct UiFileConfig {
     window_height: Option<f32>,
     language: Option<String>,
     animations_enabled: Option<bool>,
+    tab_bar_position: Option<TabBarPosition>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -328,6 +344,7 @@ pub struct AppConfigUpdates {
     /// `None` = no change; `Some("auto"|"")` = clear; `Some("<tag>")` = set.
     pub language: Option<String>,
     pub animations_enabled: Option<bool>,
+    pub tab_bar_position: Option<TabBarPosition>,
     pub terminal_font_selection: Option<String>,
     pub terminal_font_size: Option<f32>,
     pub terminal_padding_x: Option<f32>,
@@ -369,6 +386,7 @@ impl Default for AppConfig {
                 window_height: DEFAULT_WINDOW_HEIGHT,
                 language: None,
                 animations_enabled: DEFAULT_ANIMATIONS_ENABLED,
+                tab_bar_position: TabBarPosition::default(),
             },
             terminal: TerminalConfig {
                 cell_width,
@@ -439,6 +457,9 @@ impl AppConfig {
         }
         if let Some(enabled) = updates.animations_enabled {
             self.ui.animations_enabled = enabled;
+        }
+        if let Some(position) = updates.tab_bar_position {
+            self.ui.tab_bar_position = position;
         }
         let old_font = self.terminal.font_selection.clone();
         if let Some(selection) = updates.terminal_font_selection {
@@ -576,6 +597,9 @@ impl AppConfig {
             }
             if let Some(enabled) = ui.animations_enabled {
                 self.ui.animations_enabled = enabled;
+            }
+            if let Some(position) = ui.tab_bar_position {
+                self.ui.tab_bar_position = position;
             }
         }
 
@@ -962,6 +986,7 @@ impl From<&AppConfig> for FileConfig {
                 window_height: Some(config.ui.window_height),
                 language: config.ui.language.clone(),
                 animations_enabled: Some(config.ui.animations_enabled),
+                tab_bar_position: Some(config.ui.tab_bar_position),
             }),
             terminal: Some(TerminalFileConfig {
                 cell_width: None,

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -36,6 +36,7 @@ pub enum Message {
     SettingsInputCommitted(SettingsField, String),
     SettingsBlurToggled(bool),
     SettingsAnimationsToggled(bool),
+    SettingsTabBarPositionSelected(crate::config::TabBarPosition),
     SettingsBracketedPasteToggled(bool),
     SettingsMultilinePasteConfirmToggled(bool),
     SettingsCursorShapeSelected(crate::config::CursorShape),

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -489,6 +489,10 @@ impl App {
                 self.settings_draft.animations_enabled = enabled;
                 return self.apply_settings(true);
             }
+            Message::SettingsTabBarPositionSelected(pos) => {
+                self.settings_draft.tab_bar_position = pos;
+                return self.apply_settings(true);
+            }
             Message::SettingsBracketedPasteToggled(enabled) => {
                 self.settings_draft.bracketed_paste = enabled;
                 return self.apply_settings(true);

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -7,6 +7,7 @@ mod shell_picker;
 pub(in crate::gui) use dialog::{DialogButton, confirm_dialog};
 
 use super::{App, Message, SETTINGS_TAB_INDEX};
+use crate::config::TabBarPosition;
 use crate::gui::components::context_menu::{ContextMenuItem, context_menu};
 use crate::gui::components::ime_wrapper::ImeEnabled;
 use crate::gui::components::{panel, secondary as button_secondary, tab_bar};
@@ -62,6 +63,7 @@ impl App {
             self.drag_target,
             palette,
             self.config.ui.animations_enabled,
+            self.config.ui.tab_bar_position,
         );
 
         let main_content: Element<Message> = if self.active_tab == SETTINGS_TAB_INDEX {
@@ -72,9 +74,18 @@ impl App {
             self.view_lobby(palette)
         };
 
+        let layout = match self.config.ui.tab_bar_position {
+            TabBarPosition::Top => column(vec![tab_row, main_content]),
+            TabBarPosition::Bottom => column(vec![
+                crate::gui::components::tab_bar::window_chrome(palette, bar_alpha),
+                main_content,
+                tab_row,
+            ]),
+        };
+
         let panel_background = Some(self.theme_background_color());
         let base_layout = panel(
-            column(vec![tab_row, main_content]).height(Length::Fill),
+            layout.height(Length::Fill),
             panel_background,
             self.theme_text_color(),
         )

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -1,3 +1,4 @@
+use crate::config::TabBarPosition;
 use crate::gui::app::Message;
 use crate::gui::components::{HoverStyle, button as button_factory, hover_fade};
 use crate::gui::theme::Palette;
@@ -17,6 +18,7 @@ pub fn tab_bar<'a>(
     drag_target: Option<usize>,
     palette: Palette,
     animations_enabled: bool,
+    position: TabBarPosition,
 ) -> Element<'a, Message> {
     let mut tab_elements: Vec<Element<Message>> = Vec::new();
     let is_reordering =
@@ -83,55 +85,15 @@ pub fn tab_bar<'a>(
         .width(Length::Fill)
         .height(Length::Shrink);
 
-    // macOS: left control buttons
+    let is_top = position == TabBarPosition::Top;
+
+    // macOS: traffic-light space only when chrome is integrated (Top mode).
     #[cfg(target_os = "macos")]
-    let left_padding = 80.0;
+    let left_padding = if is_top { 80.0 } else { 0.0 };
     #[cfg(not(target_os = "macos"))]
     let left_padding = 0.0;
 
     let padding = iced::Padding::new(0.0).left(left_padding);
-
-    // Windows: right control buttons
-    #[cfg(target_os = "windows")]
-    let window_controls = {
-        let hover_subtle = Color {
-            a: 0.15,
-            ..palette.text
-        };
-        let hover_close = Color::from_rgb(0.9, 0.2, 0.2);
-
-        let win_style = move |hover_color: Color| {
-            move |_theme: &Theme, status: button::Status| button::Style {
-                background: match status {
-                    button::Status::Hovered => Some(Background::Color(hover_color)),
-                    _ => Some(Background::Color(Color::TRANSPARENT)),
-                },
-                text_color: match status {
-                    button::Status::Hovered => Color::WHITE,
-                    _ => palette.text_secondary,
-                },
-                border: Border::default(),
-                shadow: iced::Shadow::default(),
-                snap: true,
-            }
-        };
-
-        row![
-            button(text("\u{2500}").size(12))
-                .on_press(Message::WindowMinimize)
-                .padding([6, 12])
-                .style(win_style(hover_subtle)),
-            button(text("\u{25a1}").size(12))
-                .on_press(Message::WindowMaximize)
-                .padding([6, 12])
-                .style(win_style(hover_subtle)),
-            button(text("\u{2715}").size(12))
-                .on_press(Message::Exit)
-                .padding([6, 12])
-                .style(win_style(hover_close)),
-        ]
-        .spacing(0)
-    };
 
     let mut trailing: Vec<Element<Message>> = Vec::new();
     if let Some(btn) = sftp_btn {
@@ -140,16 +102,20 @@ pub fn tab_bar<'a>(
     trailing.push(add_btn);
     trailing.push(settings_btn);
 
+    // Windows: window controls live in the bar only when chrome is integrated.
     #[cfg(target_os = "windows")]
     let content = {
         let mut items: Vec<Element<Message>> = vec![tabs_scroll.into()];
         items.extend(trailing);
-        items.push(window_controls.into());
+        if is_top {
+            items.push(window_controls(palette).into());
+        }
         row(items).spacing(2).align_y(iced::Alignment::Center)
     };
 
     #[cfg(not(target_os = "windows"))]
     let content = {
+        let _ = is_top;
         let mut items: Vec<Element<Message>> = vec![tabs_scroll.into()];
         items.extend(trailing);
         row(items).spacing(2).align_y(iced::Alignment::Center)
@@ -179,6 +145,101 @@ pub fn tab_bar<'a>(
 
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     tab_bar_container.into()
+}
+
+/// Windows min/max/close controls. Shared by the integrated (Top) tab bar and
+/// the standalone `window_chrome` strip used in Bottom mode.
+#[cfg(target_os = "windows")]
+fn window_controls<'a>(palette: Palette) -> iced::widget::Row<'a, Message> {
+    let hover_subtle = Color {
+        a: 0.15,
+        ..palette.text
+    };
+    let hover_close = Color::from_rgb(0.9, 0.2, 0.2);
+
+    let win_style = move |hover_color: Color| {
+        move |_theme: &Theme, status: button::Status| button::Style {
+            background: match status {
+                button::Status::Hovered => Some(Background::Color(hover_color)),
+                _ => Some(Background::Color(Color::TRANSPARENT)),
+            },
+            text_color: match status {
+                button::Status::Hovered => Color::WHITE,
+                _ => palette.text_secondary,
+            },
+            border: Border::default(),
+            shadow: iced::Shadow::default(),
+            snap: true,
+        }
+    };
+
+    row![
+        button(text("\u{2500}").size(12))
+            .on_press(Message::WindowMinimize)
+            .padding([6, 12])
+            .style(win_style(hover_subtle)),
+        button(text("\u{25a1}").size(12))
+            .on_press(Message::WindowMaximize)
+            .padding([6, 12])
+            .style(win_style(hover_subtle)),
+        button(text("\u{2715}").size(12))
+            .on_press(Message::Exit)
+            .padding([6, 12])
+            .style(win_style(hover_close)),
+    ]
+    .spacing(0)
+}
+
+/// Standalone window-chrome strip rendered at the top in Bottom mode, so the
+/// native controls / drag region stay at the top of the window.
+#[cfg(target_os = "windows")]
+pub fn window_chrome<'a>(palette: Palette, bar_alpha: f32) -> Element<'a, Message> {
+    let bar_alpha = bar_alpha.clamp(0.0, 1.0);
+    let strip = container(
+        row![
+            iced::widget::Space::new().width(Length::Fill),
+            window_controls(palette),
+        ]
+        .align_y(iced::Alignment::Center),
+    )
+    .style(move |_theme: &Theme| chrome_bar_style(palette, bar_alpha))
+    .width(Length::Fill);
+    mouse_area(strip).on_press(Message::WindowDrag).into()
+}
+
+#[cfg(target_os = "macos")]
+pub fn window_chrome<'a>(palette: Palette, bar_alpha: f32) -> Element<'a, Message> {
+    let bar_alpha = bar_alpha.clamp(0.0, 1.0);
+    let strip = container(iced::widget::Space::new().width(Length::Fill))
+        .style(move |_theme: &Theme| chrome_bar_style(palette, bar_alpha))
+        .padding(iced::Padding::new(0.0).left(80.0))
+        .width(Length::Fill)
+        .height(Length::Fixed(32.0));
+    mouse_area(strip).on_press(Message::WindowDrag).into()
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+pub fn window_chrome<'a>(_palette: Palette, _bar_alpha: f32) -> Element<'a, Message> {
+    iced::widget::Space::new()
+        .width(Length::Fill)
+        .height(Length::Fixed(0.0))
+        .into()
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn chrome_bar_style(palette: Palette, bar_alpha: f32) -> container::Style {
+    container::Style {
+        background: Some(Background::Color(Color {
+            a: bar_alpha,
+            ..palette.surface
+        })),
+        border: Border {
+            radius: 0.0.into(),
+            width: 0.0,
+            color: Color::TRANSPARENT,
+        },
+        ..Default::default()
+    }
 }
 
 fn browser_tab<'a>(

--- a/src/gui/settings/appearance.rs
+++ b/src/gui/settings/appearance.rs
@@ -1,4 +1,4 @@
-use crate::config::AppConfig;
+use crate::config::{AppConfig, TabBarPosition};
 use crate::gui::app::Message;
 use crate::gui::components::{
     accent_combo_box_input_style, accent_combo_box_menu_style, accent_toggler_style,
@@ -119,15 +119,43 @@ pub fn view<'a>(
         palette,
     );
 
+    let tabs_section = section(
+        crate::t!("settings.appearance.tabs_section"),
+        segmented_control(
+            crate::t!("settings.appearance.position"),
+            TabBarPosition::ALL
+                .iter()
+                .map(|&pos| {
+                    (
+                        tab_bar_position_label(pos),
+                        Message::SettingsTabBarPositionSelected(pos),
+                        draft.tab_bar_position == pos,
+                    )
+                })
+                .collect(),
+            palette,
+            config.ui.animations_enabled,
+        ),
+        palette,
+    );
+
     column(vec![
         language_section,
         animations_section,
+        tabs_section,
         font_section,
         padding_section,
     ])
     .spacing(SPACING_NORMAL)
     .width(Length::Fill)
     .into()
+}
+
+fn tab_bar_position_label(position: TabBarPosition) -> &'static str {
+    match position {
+        TabBarPosition::Top => crate::t!("settings.appearance.tab_position.top"),
+        TabBarPosition::Bottom => crate::t!("settings.appearance.tab_position.bottom"),
+    }
 }
 
 fn language_picker<'a>(

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::{
     AppConfig, AppConfigUpdates, BellMode, CursorShape, RightClickAction, SshAuthMethod,
-    SshProfile, parse_hex_color,
+    SshProfile, TabBarPosition, parse_hex_color,
 };
 use crate::gui::app::Message;
 use crate::gui::components::accent_toggler_style;
@@ -232,6 +232,7 @@ pub struct SettingsDraft {
     pub background_opacity: String,
     pub blur_enabled: bool,
     pub animations_enabled: bool,
+    pub tab_bar_position: TabBarPosition,
     pub macos_blur_radius: String,
     pub shortcut_new_tab: String,
     pub shortcut_close_tab: String,
@@ -274,6 +275,7 @@ impl SettingsDraft {
             background_opacity: format!("{:.2}", config.theme.background_opacity),
             blur_enabled: config.theme.blur_enabled,
             animations_enabled: config.ui.animations_enabled,
+            tab_bar_position: config.ui.tab_bar_position,
             macos_blur_radius: format!("{}", config.theme.macos_blur_radius),
             shortcut_new_tab: config.shortcuts.new_tab.clone(),
             shortcut_close_tab: config.shortcuts.close_tab.clone(),
@@ -475,6 +477,7 @@ impl SettingsDraft {
         let mut updates = AppConfigUpdates {
             language: Some(self.language.clone()),
             animations_enabled: Some(self.animations_enabled),
+            tab_bar_position: Some(self.tab_bar_position),
             terminal_font_selection: Some(self.terminal_font_selection.clone()),
             terminal_font_size: parse_f32(&self.terminal_font_size),
             terminal_padding_x: parse_f32(&self.terminal_padding_x),


### PR DESCRIPTION
Closes #171.

탭바를 상단/하단에 배치하는 설정.

## 변경
- `UiConfig.tab_bar_position: TabBarPosition { Top, Bottom }` (기본 Top) + plumbing
- 모양(Appearance) 카테고리 "Tabs" 섹션 세그먼트 컨트롤 (위/아래) + i18n
- `tab_bar`에 `position` 인자 — Bottom이면 Windows 컨트롤/macOS 패딩 제외하고 탭 스트립만
- 신규 `window_chrome()` (Bottom 시 상단 스트립): Windows=우상단 컨트롤+드래그, macOS=신호등 자리(좌패딩+높이)+드래그, Linux=0 높이 no-op
- `view_main` 레이아웃을 position 따라 구성 (Bottom = `[window_chrome, content, tab_strip]`)
- 드래그 영역(WindowDrag) macOS/Windows 유지

build / clippy / test(--lib, 57 passed) / fmt 통과 (macOS 로컬). Windows/Linux cfg 브랜치는 CI 검증.