### PR TITLE
터미널 벨 동작에 대한 기본값을 플랫폼별 기본 사운드로 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Rabbitty is a terminal emulator chasing `foot`-like memory thrift and cross-plat
 ## Install
 
 **Linux / macOS:**
-```sh
+```
 curl -fsSL https://raw.githubusercontent.com/wHoIsDReAmer/RabbiTTY/main/install.sh | sh
 ```
 
@@ -35,11 +35,14 @@ The Unix script installs the binary to `~/.local/bin/rabbitty`. On Linux it also
 
 ## Goals
 
+- [x] Support customizable themes
 - [x] SSH Managing
+- [ ] Profile customization
+- [ ] Support serial connection
 - [ ] Plugin support with wasm
 - [x] Easy changing theme
 - [x] i18n (English, 한국어)
-- [ ] Easy file upload & download with SFTP
+- [x] Easy file upload & download with SFTP
 - [ ] Split terminal in single tab
 
 ## Custom Themes

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -42,6 +42,12 @@ auto = "Auto"
 [settings.appearance]
 animations_section = "Animations"
 animations = "Enable animations"
+tabs_section = "Tabs"
+position = "Position"
+
+[settings.appearance.tab_position]
+top = "Top"
+bottom = "Bottom"
 
 [settings.terminal]
 font_section = "Font"

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -42,6 +42,12 @@ auto = "자동"
 [settings.appearance]
 animations_section = "애니메이션"
 animations = "애니메이션 사용"
+tabs_section = "탭"
+position = "위치"
+
+[settings.appearance.tab_position]
+top = "위"
+bottom = "아래"
 
 [settings.terminal]
 font_section = "글꼴"

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,8 +112,8 @@ impl std::fmt::Display for CursorShape {
 #[serde(rename_all = "snake_case")]
 pub enum BellMode {
     Off,
-    #[default]
     Visual,
+    #[default]
     Sound,
 }
 
@@ -1097,7 +1097,7 @@ fn ensure_config_file(path: &Path) -> std::io::Result<()> {
 
 fn default_config_toml() -> String {
     format!(
-        "[ui]\nwindow_width = {width}\nwindow_height = {height}\n\n[terminal]\nfont_selection = \"\"\nfont_size = {font_size:.1}\npadding_x = {padding_x:.1}\npadding_y = {padding_y:.1}\n\n[theme]\ncolor_scheme = \"Catppuccin Mocha\"\nforeground = \"#{fg:02x}{fg_g:02x}{fg_b:02x}\"\nbackground = \"#{bg:02x}{bg_g:02x}{bg_b:02x}\"\ncursor = \"#{cur:02x}{cur_g:02x}{cur_b:02x}\"\nbackground_opacity = {opacity:.2}\nblur_enabled = {blur_enabled}\nmacos_blur_radius = {macos_blur_radius}\n\n[shortcuts]\nnew_tab = \"{shortcut_new_tab}\"\nclose_tab = \"{shortcut_close_tab}\"\nopen_settings = \"{shortcut_open_settings}\"\nnext_tab = \"{shortcut_next_tab}\"\nprev_tab = \"{shortcut_prev_tab}\"\nquit = \"{shortcut_quit}\"\nfont_size_increase = \"{shortcut_font_size_increase}\"\nfont_size_decrease = \"{shortcut_font_size_decrease}\"\nfont_size_reset = \"{shortcut_font_size_reset}\"\nduplicate_tab = \"{shortcut_duplicate_tab}\"\n",
+        "[ui]\nwindow_width = {width}\nwindow_height = {height}\n\n[terminal]\nfont_selection = \"\"\nfont_size = {font_size:.1}\npadding_x = {padding_x:.1}\npadding_y = {padding_y:.1}\nbell_mode = \"sound\"\n\n[theme]\ncolor_scheme = \"Catppuccin Mocha\"\nforeground = \"#{fg:02x}{fg_g:02x}{fg_b:02x}\"\nbackground = \"#{bg:02x}{bg_g:02x}{bg_b:02x}\"\ncursor = \"#{cur:02x}{cur_g:02x}{cur_b:02x}\"\nbackground_opacity = {opacity:.2}\nblur_enabled = {blur_enabled}\nmacos_blur_radius = {macos_blur_radius}\n\n[shortcuts]\nnew_tab = \"{shortcut_new_tab}\"\nclose_tab = \"{shortcut_close_tab}\"\nopen_settings = \"{shortcut_open_settings}\"\nnext_tab = \"{shortcut_next_tab}\"\nprev_tab = \"{shortcut_prev_tab}\"\nquit = \"{shortcut_quit}\"\nfont_size_increase = \"{shortcut_font_size_increase}\"\nfont_size_decrease = \"{shortcut_font_size_decrease}\"\nfont_size_reset = \"{shortcut_font_size_reset}\"\nduplicate_tab = \"{shortcut_duplicate_tab}\"\n",
         width = DEFAULT_WINDOW_WIDTH as u32,
         height = DEFAULT_WINDOW_HEIGHT as u32,
         font_size = DEFAULT_TERMINAL_FONT_SIZE,
@@ -1294,6 +1294,25 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(config.terminal.font_size, default_size);
+    }
+
+    #[test]
+    fn terminal_bell_defaults_to_sound() {
+        let config = AppConfig::default();
+
+        assert_eq!(config.terminal.bell_mode, BellMode::Sound);
+    }
+
+    #[test]
+    fn generated_default_config_exposes_sound_bell_mode() {
+        let toml_str = default_config_toml();
+        let file = toml::from_str::<FileConfig>(&toml_str).expect("default config should parse");
+
+        assert!(toml_str.contains("bell_mode = \"sound\""));
+        assert_eq!(
+            file.terminal.and_then(|terminal| terminal.bell_mode),
+            Some(BellMode::Sound)
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,6 +132,19 @@ impl std::fmt::Display for BellMode {
     }
 }
 
+/// Where the tab bar (which doubles as the title bar) is anchored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TabBarPosition {
+    #[default]
+    Top,
+    Bottom,
+}
+
+impl TabBarPosition {
+    pub const ALL: [Self; 2] = [Self::Top, Self::Bottom];
+}
+
 /// Action taken when the terminal area is right-clicked.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -201,6 +214,8 @@ pub struct UiConfig {
     pub language: Option<String>,
     /// Whether smooth hover transition animations are enabled.
     pub animations_enabled: bool,
+    /// Where the tab bar / title bar is anchored.
+    pub tab_bar_position: TabBarPosition,
 }
 
 #[derive(Debug, Clone)]
@@ -273,6 +288,7 @@ struct UiFileConfig {
     window_height: Option<f32>,
     language: Option<String>,
     animations_enabled: Option<bool>,
+    tab_bar_position: Option<TabBarPosition>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -328,6 +344,7 @@ pub struct AppConfigUpdates {
     /// `None` = no change; `Some("auto"|"")` = clear; `Some("<tag>")` = set.
     pub language: Option<String>,
     pub animations_enabled: Option<bool>,
+    pub tab_bar_position: Option<TabBarPosition>,
     pub terminal_font_selection: Option<String>,
     pub terminal_font_size: Option<f32>,
     pub terminal_padding_x: Option<f32>,
@@ -369,6 +386,7 @@ impl Default for AppConfig {
                 window_height: DEFAULT_WINDOW_HEIGHT,
                 language: None,
                 animations_enabled: DEFAULT_ANIMATIONS_ENABLED,
+                tab_bar_position: TabBarPosition::default(),
             },
             terminal: TerminalConfig {
                 cell_width,
@@ -439,6 +457,9 @@ impl AppConfig {
         }
         if let Some(enabled) = updates.animations_enabled {
             self.ui.animations_enabled = enabled;
+        }
+        if let Some(position) = updates.tab_bar_position {
+            self.ui.tab_bar_position = position;
         }
         let old_font = self.terminal.font_selection.clone();
         if let Some(selection) = updates.terminal_font_selection {
@@ -576,6 +597,9 @@ impl AppConfig {
             }
             if let Some(enabled) = ui.animations_enabled {
                 self.ui.animations_enabled = enabled;
+            }
+            if let Some(position) = ui.tab_bar_position {
+                self.ui.tab_bar_position = position;
             }
         }
 
@@ -962,6 +986,7 @@ impl From<&AppConfig> for FileConfig {
                 window_height: Some(config.ui.window_height),
                 language: config.ui.language.clone(),
                 animations_enabled: Some(config.ui.animations_enabled),
+                tab_bar_position: Some(config.ui.tab_bar_position),
             }),
             terminal: Some(TerminalFileConfig {
                 cell_width: None,

--- a/src/gui/app/mod.rs
+++ b/src/gui/app/mod.rs
@@ -36,6 +36,7 @@ pub enum Message {
     SettingsInputCommitted(SettingsField, String),
     SettingsBlurToggled(bool),
     SettingsAnimationsToggled(bool),
+    SettingsTabBarPositionSelected(crate::config::TabBarPosition),
     SettingsBracketedPasteToggled(bool),
     SettingsMultilinePasteConfirmToggled(bool),
     SettingsCursorShapeSelected(crate::config::CursorShape),

--- a/src/gui/app/update/mod.rs
+++ b/src/gui/app/update/mod.rs
@@ -489,6 +489,10 @@ impl App {
                 self.settings_draft.animations_enabled = enabled;
                 return self.apply_settings(true);
             }
+            Message::SettingsTabBarPositionSelected(pos) => {
+                self.settings_draft.tab_bar_position = pos;
+                return self.apply_settings(true);
+            }
             Message::SettingsBracketedPasteToggled(enabled) => {
                 self.settings_draft.bracketed_paste = enabled;
                 return self.apply_settings(true);

--- a/src/gui/app/view/mod.rs
+++ b/src/gui/app/view/mod.rs
@@ -7,6 +7,7 @@ mod shell_picker;
 pub(in crate::gui) use dialog::{DialogButton, confirm_dialog};
 
 use super::{App, Message, SETTINGS_TAB_INDEX};
+use crate::config::TabBarPosition;
 use crate::gui::components::context_menu::{ContextMenuItem, context_menu};
 use crate::gui::components::ime_wrapper::ImeEnabled;
 use crate::gui::components::{panel, secondary as button_secondary, tab_bar};
@@ -62,6 +63,7 @@ impl App {
             self.drag_target,
             palette,
             self.config.ui.animations_enabled,
+            self.config.ui.tab_bar_position,
         );
 
         let main_content: Element<Message> = if self.active_tab == SETTINGS_TAB_INDEX {
@@ -72,9 +74,18 @@ impl App {
             self.view_lobby(palette)
         };
 
+        let layout = match self.config.ui.tab_bar_position {
+            TabBarPosition::Top => column(vec![tab_row, main_content]),
+            TabBarPosition::Bottom => column(vec![
+                crate::gui::components::tab_bar::window_chrome(palette, bar_alpha),
+                main_content,
+                tab_row,
+            ]),
+        };
+
         let panel_background = Some(self.theme_background_color());
         let base_layout = panel(
-            column(vec![tab_row, main_content]).height(Length::Fill),
+            layout.height(Length::Fill),
             panel_background,
             self.theme_text_color(),
         )

--- a/src/gui/components/tab_bar.rs
+++ b/src/gui/components/tab_bar.rs
@@ -1,3 +1,4 @@
+use crate::config::TabBarPosition;
 use crate::gui::app::Message;
 use crate::gui::components::{HoverStyle, button as button_factory, hover_fade};
 use crate::gui::theme::Palette;
@@ -17,6 +18,7 @@ pub fn tab_bar<'a>(
     drag_target: Option<usize>,
     palette: Palette,
     animations_enabled: bool,
+    position: TabBarPosition,
 ) -> Element<'a, Message> {
     let mut tab_elements: Vec<Element<Message>> = Vec::new();
     let is_reordering =
@@ -83,55 +85,15 @@ pub fn tab_bar<'a>(
         .width(Length::Fill)
         .height(Length::Shrink);
 
-    // macOS: left control buttons
+    let is_top = position == TabBarPosition::Top;
+
+    // macOS: traffic-light space only when chrome is integrated (Top mode).
     #[cfg(target_os = "macos")]
-    let left_padding = 80.0;
+    let left_padding = if is_top { 80.0 } else { 0.0 };
     #[cfg(not(target_os = "macos"))]
     let left_padding = 0.0;
 
     let padding = iced::Padding::new(0.0).left(left_padding);
-
-    // Windows: right control buttons
-    #[cfg(target_os = "windows")]
-    let window_controls = {
-        let hover_subtle = Color {
-            a: 0.15,
-            ..palette.text
-        };
-        let hover_close = Color::from_rgb(0.9, 0.2, 0.2);
-
-        let win_style = move |hover_color: Color| {
-            move |_theme: &Theme, status: button::Status| button::Style {
-                background: match status {
-                    button::Status::Hovered => Some(Background::Color(hover_color)),
-                    _ => Some(Background::Color(Color::TRANSPARENT)),
-                },
-                text_color: match status {
-                    button::Status::Hovered => Color::WHITE,
-                    _ => palette.text_secondary,
-                },
-                border: Border::default(),
-                shadow: iced::Shadow::default(),
-                snap: true,
-            }
-        };
-
-        row![
-            button(text("\u{2500}").size(12))
-                .on_press(Message::WindowMinimize)
-                .padding([6, 12])
-                .style(win_style(hover_subtle)),
-            button(text("\u{25a1}").size(12))
-                .on_press(Message::WindowMaximize)
-                .padding([6, 12])
-                .style(win_style(hover_subtle)),
-            button(text("\u{2715}").size(12))
-                .on_press(Message::Exit)
-                .padding([6, 12])
-                .style(win_style(hover_close)),
-        ]
-        .spacing(0)
-    };
 
     let mut trailing: Vec<Element<Message>> = Vec::new();
     if let Some(btn) = sftp_btn {
@@ -140,16 +102,20 @@ pub fn tab_bar<'a>(
     trailing.push(add_btn);
     trailing.push(settings_btn);
 
+    // Windows: window controls live in the bar only when chrome is integrated.
     #[cfg(target_os = "windows")]
     let content = {
         let mut items: Vec<Element<Message>> = vec![tabs_scroll.into()];
         items.extend(trailing);
-        items.push(window_controls.into());
+        if is_top {
+            items.push(window_controls(palette).into());
+        }
         row(items).spacing(2).align_y(iced::Alignment::Center)
     };
 
     #[cfg(not(target_os = "windows"))]
     let content = {
+        let _ = is_top;
         let mut items: Vec<Element<Message>> = vec![tabs_scroll.into()];
         items.extend(trailing);
         row(items).spacing(2).align_y(iced::Alignment::Center)
@@ -179,6 +145,101 @@ pub fn tab_bar<'a>(
 
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     tab_bar_container.into()
+}
+
+/// Windows min/max/close controls. Shared by the integrated (Top) tab bar and
+/// the standalone `window_chrome` strip used in Bottom mode.
+#[cfg(target_os = "windows")]
+fn window_controls<'a>(palette: Palette) -> iced::widget::Row<'a, Message> {
+    let hover_subtle = Color {
+        a: 0.15,
+        ..palette.text
+    };
+    let hover_close = Color::from_rgb(0.9, 0.2, 0.2);
+
+    let win_style = move |hover_color: Color| {
+        move |_theme: &Theme, status: button::Status| button::Style {
+            background: match status {
+                button::Status::Hovered => Some(Background::Color(hover_color)),
+                _ => Some(Background::Color(Color::TRANSPARENT)),
+            },
+            text_color: match status {
+                button::Status::Hovered => Color::WHITE,
+                _ => palette.text_secondary,
+            },
+            border: Border::default(),
+            shadow: iced::Shadow::default(),
+            snap: true,
+        }
+    };
+
+    row![
+        button(text("\u{2500}").size(12))
+            .on_press(Message::WindowMinimize)
+            .padding([6, 12])
+            .style(win_style(hover_subtle)),
+        button(text("\u{25a1}").size(12))
+            .on_press(Message::WindowMaximize)
+            .padding([6, 12])
+            .style(win_style(hover_subtle)),
+        button(text("\u{2715}").size(12))
+            .on_press(Message::Exit)
+            .padding([6, 12])
+            .style(win_style(hover_close)),
+    ]
+    .spacing(0)
+}
+
+/// Standalone window-chrome strip rendered at the top in Bottom mode, so the
+/// native controls / drag region stay at the top of the window.
+#[cfg(target_os = "windows")]
+pub fn window_chrome<'a>(palette: Palette, bar_alpha: f32) -> Element<'a, Message> {
+    let bar_alpha = bar_alpha.clamp(0.0, 1.0);
+    let strip = container(
+        row![
+            iced::widget::Space::new().width(Length::Fill),
+            window_controls(palette),
+        ]
+        .align_y(iced::Alignment::Center),
+    )
+    .style(move |_theme: &Theme| chrome_bar_style(palette, bar_alpha))
+    .width(Length::Fill);
+    mouse_area(strip).on_press(Message::WindowDrag).into()
+}
+
+#[cfg(target_os = "macos")]
+pub fn window_chrome<'a>(palette: Palette, bar_alpha: f32) -> Element<'a, Message> {
+    let bar_alpha = bar_alpha.clamp(0.0, 1.0);
+    let strip = container(iced::widget::Space::new().width(Length::Fill))
+        .style(move |_theme: &Theme| chrome_bar_style(palette, bar_alpha))
+        .padding(iced::Padding::new(0.0).left(80.0))
+        .width(Length::Fill)
+        .height(Length::Fixed(32.0));
+    mouse_area(strip).on_press(Message::WindowDrag).into()
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+pub fn window_chrome<'a>(_palette: Palette, _bar_alpha: f32) -> Element<'a, Message> {
+    iced::widget::Space::new()
+        .width(Length::Fill)
+        .height(Length::Fixed(0.0))
+        .into()
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn chrome_bar_style(palette: Palette, bar_alpha: f32) -> container::Style {
+    container::Style {
+        background: Some(Background::Color(Color {
+            a: bar_alpha,
+            ..palette.surface
+        })),
+        border: Border {
+            radius: 0.0.into(),
+            width: 0.0,
+            color: Color::TRANSPARENT,
+        },
+        ..Default::default()
+    }
 }
 
 fn browser_tab<'a>(

--- a/src/gui/settings/appearance.rs
+++ b/src/gui/settings/appearance.rs
@@ -1,4 +1,4 @@
-use crate::config::AppConfig;
+use crate::config::{AppConfig, TabBarPosition};
 use crate::gui::app::Message;
 use crate::gui::components::{
     accent_combo_box_input_style, accent_combo_box_menu_style, accent_toggler_style,
@@ -119,15 +119,43 @@ pub fn view<'a>(
         palette,
     );
 
+    let tabs_section = section(
+        crate::t!("settings.appearance.tabs_section"),
+        segmented_control(
+            crate::t!("settings.appearance.position"),
+            TabBarPosition::ALL
+                .iter()
+                .map(|&pos| {
+                    (
+                        tab_bar_position_label(pos),
+                        Message::SettingsTabBarPositionSelected(pos),
+                        draft.tab_bar_position == pos,
+                    )
+                })
+                .collect(),
+            palette,
+            config.ui.animations_enabled,
+        ),
+        palette,
+    );
+
     column(vec![
         language_section,
         animations_section,
+        tabs_section,
         font_section,
         padding_section,
     ])
     .spacing(SPACING_NORMAL)
     .width(Length::Fill)
     .into()
+}
+
+fn tab_bar_position_label(position: TabBarPosition) -> &'static str {
+    match position {
+        TabBarPosition::Top => crate::t!("settings.appearance.tab_position.top"),
+        TabBarPosition::Bottom => crate::t!("settings.appearance.tab_position.bottom"),
+    }
 }
 
 fn language_picker<'a>(

--- a/src/gui/settings/mod.rs
+++ b/src/gui/settings/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::{
     AppConfig, AppConfigUpdates, BellMode, CursorShape, RightClickAction, SshAuthMethod,
-    SshProfile, parse_hex_color,
+    SshProfile, TabBarPosition, parse_hex_color,
 };
 use crate::gui::app::Message;
 use crate::gui::components::accent_toggler_style;
@@ -232,6 +232,7 @@ pub struct SettingsDraft {
     pub background_opacity: String,
     pub blur_enabled: bool,
     pub animations_enabled: bool,
+    pub tab_bar_position: TabBarPosition,
     pub macos_blur_radius: String,
     pub shortcut_new_tab: String,
     pub shortcut_close_tab: String,
@@ -274,6 +275,7 @@ impl SettingsDraft {
             background_opacity: format!("{:.2}", config.theme.background_opacity),
             blur_enabled: config.theme.blur_enabled,
             animations_enabled: config.ui.animations_enabled,
+            tab_bar_position: config.ui.tab_bar_position,
             macos_blur_radius: format!("{}", config.theme.macos_blur_radius),
             shortcut_new_tab: config.shortcuts.new_tab.clone(),
             shortcut_close_tab: config.shortcuts.close_tab.clone(),
@@ -475,6 +477,7 @@ impl SettingsDraft {
         let mut updates = AppConfigUpdates {
             language: Some(self.language.clone()),
             animations_enabled: Some(self.animations_enabled),
+            tab_bar_position: Some(self.tab_bar_position),
             terminal_font_selection: Some(self.terminal_font_selection.clone()),
             terminal_font_size: parse_f32(&self.terminal_font_size),
             terminal_padding_x: parse_f32(&self.terminal_padding_x),


### PR DESCRIPTION
resolves: #175 

## Description
- BELL(백스페이스 등 충돌시 행위)에 대한 기본값을 번쩍거리는 시각효과에서 플랫폼별 사운드로 변경
- 이제는 OS에 따른 터미널 기본 동작을 상속받아서 동작함 (Linux는 no-op, MacOS/Windows는 beep음 발생)